### PR TITLE
[BUGFIX] Fixed telemetry based conformance monitoring

### DIFF
--- a/conformance_monitoring_operations/tasks.py
+++ b/conformance_monitoring_operations/tasks.py
@@ -59,7 +59,6 @@ def check_operation_telemetry_conformance(flight_declaration_id: str, dry_run: s
         logger.error("No telemetry data found for operation {flight_operation_id}".format(flight_operation_id=flight_declaration_id))
         return
 
-
     all_flights_rid_data.sort(key=lambda item: item["timestamp"], reverse=True)
     distinct_messages = {i["address"]: i for i in reversed(all_flights_rid_data)}.values()
 


### PR DESCRIPTION
There is a bug when raising non conformant status for Telemetry based conformance monitoring. It is fixed in this PR as per below instructions.

Possible values for `conformant_via_telemetry` are True, 3,4,5,6,7,8 etc.

With below condition, the non conformant status will not be raised when the status values are 3,4,5,6 etc.

Bug:

```python
            if conformant_via_telemetry:
                pass
``` 

Fix:

```python
            if conformant_via_telemetry is True:
                pass
``` 