### PR TITLE
Bumped dev db-blender postgres version to latest

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -16,7 +16,7 @@ services:
   db-blender:
     platform: linux/amd64
     container_name: "db-blender"
-    image: postgres:17
+    image: postgres:latest
     ports:
       - "5432:5432"
     expose:


### PR DESCRIPTION
In docker-compose-dev.

With postgres version 17, db-blender keeps restarting with this log.
Bumping to latest fixes this.
```
db-blender           |
db-blender           | PostgreSQL Database directory appears to contain a database; Skipping initialization
db-blender           |
db-blender           | 2025-11-14 10:58:33.574 GMT [1] LOG:  unrecognized configuration parameter "autovacuum_worker_slots" in file "/var/lib/postgresql/data/pgdata/postgresql.conf" line 683
db-blender           | 2025-11-14 10:58:33.574 GMT [1] FATAL:  configuration file "/var/lib/postgresql/data/pgdata/postgresql.conf" contains errors
db-blender exited with code 1
```