### PR TITLE
Rename metres to meters

### DIFF
--- a/api/flight-blender-server-1.0.0-resolved.yaml
+++ b/api/flight-blender-server-1.0.0-resolved.yaml
@@ -3261,7 +3261,7 @@ components:
             max_altitude:
               type: object
               properties:
-                metres:
+                meters:
                   type: number
                 datum:
                   type: string
@@ -3270,7 +3270,7 @@ components:
             min_altitude:
               type: object
               properties:
-                metres:
+                meters:
                   type: number
                 datum:
                   type: string


### PR DESCRIPTION
The openapi yaml has the word meters typoed as metres which cause any generated API client code to fail.