### PR TITLE
Add TTL to airtraffic stream

### DIFF
--- a/common/redis_stream_operations.py
+++ b/common/redis_stream_operations.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 from typing import List, Optional
 
@@ -14,6 +15,9 @@ load_dotenv(find_dotenv())
 ENV_FILE = find_dotenv()
 if ENV_FILE:
     load_dotenv(ENV_FILE)
+
+# Read TTL for air traffic stream data from environment, default to 4000ms
+AIR_TRAFFIC_STREAM_TTL_MS = int(os.getenv("AIR_TRAFFIC_STREAM_TTL_MS", "4000"))
 
 
 class RedisStreamOperations:
@@ -51,6 +55,8 @@ class RedisStreamOperations:
                 observation["metadata"] = json.dumps(observation["metadata"])
 
             self.redis.xadd(stream_name, observation)
+            if AIR_TRAFFIC_STREAM_TTL_MS is not None:
+                self.redis.pexpire(stream_name, AIR_TRAFFIC_STREAM_TTL_MS)  # TTL is already in milliseconds
             logger.info(f"Data added to Redis stream '{stream_name}' successfully.")
             logger.debug(f"Data added to Redis stream '{stream_name}': {observation}")
         except Exception as e:

--- a/deployment_support/.env.local
+++ b/deployment_support/.env.local
@@ -15,6 +15,7 @@ REDIS_PORT=6379
 REDIS_PASSWORD=blender_redis
 REDIS_BROKER_URL=redis://:blender_redis@redis-blender:6379
 HEARTBEAT_RATE_SECS=2
+AIR_TRAFFIC_STREAM_TTL_MS=3600000 # 1 hour in milliseconds
 
 FLIGHT_SPOTLIGHT_URL=http://local.test:5000
 

--- a/flight_feed_operations/tasks.py
+++ b/flight_feed_operations/tasks.py
@@ -58,7 +58,7 @@ def write_incoming_air_traffic_data(observation: str):
 
     my_database_writer.write_flight_observation(single_air_traffic_observation)
     logger.info("Writing to Redis stream..")
-    message_id = my_redis_helper.add_air_traffic_data(stream_name="air_traffic_stream", observation=asdict(single_air_traffic_observation))
+    my_redis_helper.add_air_traffic_data(stream_name="air_traffic_stream", observation=asdict(single_air_traffic_observation))
 
 
 lonlat_to_webmercator = Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)


### PR DESCRIPTION
If we don't consume airtraffic stream within 4 seconds, its data is considered stale and it is not useful for our system. This sets TTL of 4 seconds if stream hasn't had new data in over 4 seconds.