### PR TITLE
FastAPI conversion fixes

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,2 +1,4 @@
 corus
 bord
+daa
+dependant

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ dmypy.json
 
 .vscode/settings.json
 *.sqlite3
+*.db
 celerybeat-schedule.db
 
 # Ignore rtree indexes

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,4 +22,11 @@
     "sonarlint.disableTelemetry": true,
     "python.analysis.typeCheckingMode": "basic",
     "editor.wordWrap": "on",
+    "files.exclude": {
+        "**/__pycache__": true,
+        "**/.venv": true,
+        "**/venv": true,
+        "**/.mypy_cache": true,
+        "**/.pytest_cache": true
+    }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,5 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH="/app/src"
 
 EXPOSE 8000
+
+CMD ["uvicorn", "flight_blender.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,28 +64,28 @@ services:
     networks:
       - interop_ecosystem_network
 
-  # flight-blender-celery-beat:
-  #   platform: linux/amd64
-  #   container_name: flight-blender-beat
-  #   image: openskies-sh/flight-blender
-  #   restart: on-failure
-  #   build:
-  #     context: "."
-  #   environment:
-  #     - POSTGRES_USER
-  #     - POSTGRES_PASSWORD
-  #     - POSTGRES_DB
-  #   hostname: celery-beat
-  #   command: ./entrypoints/with-database/entrypoint-beat.sh
-  #   volumes:
-  #     - .:/app
-  #   depends_on:
-  #     redis-blender:
-  #       condition: service_started
-  #     db-blender:
-  #       condition: service_started
-  #     flight-blender-celery:
-  #       condition: service_started
+  flight-blender-celery-beat:
+    platform: linux/amd64
+    container_name: flight-blender-beat
+    image: openutm/flight-blender
+    restart: on-failure
+    build:
+      context: "."
+    env_file:
+      - ".env"
+    hostname: celery-beat
+    command: ./entrypoints/with-database/entrypoint-beat.sh
+    volumes:
+      - .:/app
+    depends_on:
+      redis-blender:
+        condition: service_started
+      db-blender:
+        condition: service_started
+      flight-blender-celery:
+        condition: service_started
+    networks:
+      - interop_ecosystem_network
 
 volumes:
   app:

--- a/importers/README.md
+++ b/importers/README.md
@@ -1,3 +1,0 @@
-# Importers -> E2E Verification
-
-The Importers directory has been moved to `xtmalliance/verification` [here](https://github.com/xtmalliance/verification).

--- a/src/flight_blender/alembic_migrations/versions/ff001_session_id_index.py
+++ b/src/flight_blender/alembic_migrations/versions/ff001_session_id_index.py
@@ -1,0 +1,35 @@
+"""add index on flight_feed_observation.session_id
+
+Restores an index on ``flight_feed_observation.session_id`` for the
+latest-observation-by-session lookup hot path (the Django
+``FlightObservation`` was queried by ``session_id`` and ordered by
+``-created_at``).
+
+Revision ID: ff001_session_id_index
+Revises: rid001_view_hash_indexes
+Create Date: 2026-05-31
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ff001_session_id_index"
+down_revision: Union[str, None] = "rid001_view_hash_indexes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("flight_feed_observation") as batch_op:
+        batch_op.create_index(
+            "ix_flight_feed_observation_session_id",
+            ["session_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("flight_feed_observation") as batch_op:
+        batch_op.drop_index("ix_flight_feed_observation_session_id")

--- a/src/flight_blender/alembic_migrations/versions/nt001_notification_session_nullable.py
+++ b/src/flight_blender/alembic_migrations/versions/nt001_notification_session_nullable.py
@@ -1,0 +1,41 @@
+"""make operator_rid_notification.session_id nullable
+
+Restores Django parity for ``OperatorRIDNotification.session_id`` which was
+declared ``blank=True, null=True`` in the Django model but created as
+``nullable=False`` in the initial FastAPI tables. Operator-RID notifications may
+be persisted without a session id (e.g. the no-AMQP local-persistence fallback),
+so the column must be nullable.
+
+Revision ID: nt001_notification_session_nullable
+Revises: ff001_session_id_index
+Create Date: 2026-05-31
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "nt001_notification_session_nullable"
+down_revision: Union[str, None] = "ff001_session_id_index"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("operator_rid_notification") as batch_op:
+        batch_op.alter_column(
+            "session_id",
+            existing_type=sa.String(length=256),
+            nullable=True,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("operator_rid_notification") as batch_op:
+        batch_op.alter_column(
+            "session_id",
+            existing_type=sa.String(length=256),
+            nullable=False,
+        )

--- a/src/flight_blender/alembic_migrations/versions/rid001_view_hash_and_indexes.py
+++ b/src/flight_blender/alembic_migrations/versions/rid001_view_hash_and_indexes.py
@@ -1,0 +1,51 @@
+"""rid view_hash nullable + Django db_index columns
+
+Aligns ``rid_isa_subscription`` / ``rid_flight_detail`` with the Django
+originals (``rid_operations/models.py``):
+
+* ``rid_isa_subscription.view_hash`` becomes nullable (Django: ``null=True``).
+  FastAPI computes a *string* SHA-256 digest, so the column stays
+  ``String(64)`` rather than Django's ``IntegerField`` (documented deviation),
+  but matches the nullability.
+* Add the indexes Django declared with ``db_index=True``:
+  ``rid_isa_subscription.subscription_id``, ``rid_isa_subscription.view_hash``,
+  ``rid_isa_subscription.created_at`` and ``rid_flight_detail.created_at``.
+
+Revision ID: rid001_view_hash_indexes
+Revises: daa001_add_tables
+Create Date: 2026-05-31 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "rid001_view_hash_indexes"
+down_revision: Union[str, None] = "daa001_add_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("rid_isa_subscription") as batch_op:
+        batch_op.alter_column("view_hash", existing_type=sa.String(length=64), nullable=True)
+        batch_op.create_index("ix_rid_isa_subscription_subscription_id", ["subscription_id"], unique=False)
+        batch_op.create_index("ix_rid_isa_subscription_view_hash", ["view_hash"], unique=False)
+        batch_op.create_index("ix_rid_isa_subscription_created_at", ["created_at"], unique=False)
+
+    with op.batch_alter_table("rid_flight_detail") as batch_op:
+        batch_op.create_index("ix_rid_flight_detail_created_at", ["created_at"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("rid_flight_detail") as batch_op:
+        batch_op.drop_index("ix_rid_flight_detail_created_at")
+
+    with op.batch_alter_table("rid_isa_subscription") as batch_op:
+        batch_op.drop_index("ix_rid_isa_subscription_created_at")
+        batch_op.drop_index("ix_rid_isa_subscription_view_hash")
+        batch_op.drop_index("ix_rid_isa_subscription_subscription_id")
+        batch_op.alter_column("view_hash", existing_type=sa.String(length=64), nullable=False)

--- a/src/flight_blender/auth/__init__.py
+++ b/src/flight_blender/auth/__init__.py
@@ -1,9 +1,17 @@
 from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
-from flight_blender.auth.jwt_bearer import ReadDep, WriteDep, require_scope
+from flight_blender.auth.jwt_bearer import (
+    ReadDep,
+    RIDDisplayProviderDep,
+    RIDServiceProviderDep,
+    WriteDep,
+    require_scope,
+)
 
 __all__ = [
     "AuthorityCredentialsGetter",
     "ReadDep",
+    "RIDDisplayProviderDep",
+    "RIDServiceProviderDep",
     "WriteDep",
     "require_scope",
 ]

--- a/src/flight_blender/auth/__init__.py
+++ b/src/flight_blender/auth/__init__.py
@@ -1,5 +1,6 @@
 from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
 from flight_blender.auth.jwt_bearer import (
+    GeoAwarenessTestDep,
     ReadDep,
     RIDDisplayProviderDep,
     RIDServiceProviderDep,
@@ -9,6 +10,7 @@ from flight_blender.auth.jwt_bearer import (
 
 __all__ = [
     "AuthorityCredentialsGetter",
+    "GeoAwarenessTestDep",
     "ReadDep",
     "RIDDisplayProviderDep",
     "RIDServiceProviderDep",

--- a/src/flight_blender/auth/__init__.py
+++ b/src/flight_blender/auth/__init__.py
@@ -1,4 +1,4 @@
-from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
+from flight_blender.auth.dss import AuthorityCredentialsGetter
 from flight_blender.auth.jwt_bearer import (
     GeoAwarenessTestDep,
     ReadDep,

--- a/src/flight_blender/auth/dss.py
+++ b/src/flight_blender/auth/dss.py
@@ -1,5 +1,5 @@
 """
-DSS OAuth2 client-credentials helper (migrated from auth_helper/dss_auth_helper.py).
+DSS OAuth2 client-credentials helper.
 """
 
 import json
@@ -94,3 +94,21 @@ class AuthorityCredentialsGetter:
         if resp.status_code != 200:
             logger.error("DSS token request failed: %s %s", resp.status_code, resp.text)
         return resp.json()
+
+
+def get_dss_auth_header(audience: str, token_type: str = "scd") -> dict[str, str]:
+    """Build an Authorization header for DSS / peer-USS requests.
+
+    Parameters
+    ----------
+    audience:
+        The JWT ``aud`` claim (typically ``settings.dss_auth_audience`` or
+        ``settings.dss_self_audience``).
+    token_type:
+        Credential scope identifier forwarded to
+        :class:`AuthorityCredentialsGetter` (default ``"scd"``).
+    """
+    getter = AuthorityCredentialsGetter()
+    credentials = getter.get_cached_credentials(audience=audience, token_type=token_type)
+    access_token = credentials.get("access_token", "") if isinstance(credentials, dict) else ""
+    return {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}

--- a/src/flight_blender/auth/jwt_bearer.py
+++ b/src/flight_blender/auth/jwt_bearer.py
@@ -2,6 +2,7 @@
 JWT Bearer token verification and FastAPI security dependencies.
 """
 
+from functools import lru_cache
 from typing import Annotated
 
 import jwt
@@ -13,6 +14,18 @@ from flight_blender.config import get_settings
 settings = get_settings()
 
 _bearer = HTTPBearer(auto_error=False)
+
+
+@lru_cache(maxsize=1)
+def _get_jwks_client(jwks_uri: str) -> jwt.PyJWKClient:
+    """Return a cached ``PyJWKClient`` for *jwks_uri*.
+
+    The client is created once per distinct URI and reused for all subsequent
+    requests, avoiding an HTTP round-trip to the JWKS endpoint on every
+    authenticated call.  Tests can clear the cache via
+    ``_get_jwks_client.cache_clear()``.
+    """
+    return jwt.PyJWKClient(jwks_uri)
 
 
 def verify_bearer_token(token: str | None) -> dict:
@@ -59,7 +72,7 @@ def verify_bearer_token(token: str | None) -> dict:
     decode_kwargs["options"] = {"require": required_claims}
 
     try:
-        jwks_client = jwt.PyJWKClient(settings.auth_server_jwks_uri)
+        jwks_client = _get_jwks_client(settings.auth_server_jwks_uri)
         signing_key = jwks_client.get_signing_key_from_jwt(token)
         payload = jwt.decode(token, signing_key.key, **decode_kwargs)
     except jwt.ExpiredSignatureError as exc:

--- a/src/flight_blender/auth/jwt_bearer.py
+++ b/src/flight_blender/auth/jwt_bearer.py
@@ -15,36 +15,58 @@ settings = get_settings()
 _bearer = HTTPBearer(auto_error=False)
 
 
-async def _get_token_payload(
-    credentials: Annotated[HTTPAuthorizationCredentials | None, Security(_bearer)],
-) -> dict:
-    """Validate Bearer JWT and return its payload.
+def verify_bearer_token(token: str | None) -> dict:
+    """Verify a raw bearer token string and return its claims.
 
-    If BYPASS_AUTH_TOKEN_VERIFICATION is set the token is not verified
+    Shared by the HTTP dependency (:func:`_get_token_payload`) and the WebSocket
+    auth gate. Raises ``HTTPException`` (401) on any failure. If
+    BYPASS_AUTH_TOKEN_VERIFICATION is set the token is not verified
     (development / test mode only).
     """
     if settings.bypass_auth_token_verification:
         # Return a minimal payload with all scopes
         return {"scope": f"{settings.flightblender_read_scope} {settings.flightblender_write_scope}"}
 
-    if credentials is None:
+    if not token:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing authentication token")
 
-    token = credentials.credentials
+    # Fail CLOSED: without a JWKS source we cannot verify the signature, so we
+    # refuse to authenticate rather than trusting an unverified token. (Django's
+    # default posture was fail-closed; an unverified decode here would let any
+    # forged token through, including its ``scope`` claim.)
+    if not settings.auth_server_jwks_uri:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token verification is not configured (no JWKS URI); refusing to authenticate",
+        )
+
+    # Always require a signed, non-expiring-disallowed, issued token. Match the
+    # Django original which enforced exp/iss/aud presence and RS256 signatures.
+    required_claims = ["exp", "iss"]
+    decode_kwargs: dict = {"algorithms": ["RS256"]}
+    if settings.auth_audience:
+        decode_kwargs["audience"] = settings.auth_audience
+        required_claims.append("aud")
+    decode_kwargs["options"] = {"require": required_claims}
+
     try:
-        if settings.auth_server_jwks_uri:
-            jwks_client = jwt.PyJWKClient(settings.auth_server_jwks_uri)
-            signing_key = jwks_client.get_signing_key_from_jwt(token)
-            payload = jwt.decode(token, signing_key.key, algorithms=["RS256"])
-        else:
-            # Decode without verification (insecure – only for fully trusted local environments)
-            payload = jwt.decode(token, options={"verify_signature": False})
+        jwks_client = jwt.PyJWKClient(settings.auth_server_jwks_uri)
+        signing_key = jwks_client.get_signing_key_from_jwt(token)
+        payload = jwt.decode(token, signing_key.key, **decode_kwargs)
     except jwt.ExpiredSignatureError as exc:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired") from exc
     except jwt.InvalidTokenError as exc:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
 
     return payload
+
+
+async def _get_token_payload(
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Security(_bearer)],
+) -> dict:
+    """FastAPI dependency: validate the Bearer JWT and return its payload."""
+    token = credentials.credentials if credentials else None
+    return verify_bearer_token(token)
 
 
 def require_scope(*required_scopes: str):

--- a/src/flight_blender/auth/jwt_bearer.py
+++ b/src/flight_blender/auth/jwt_bearer.py
@@ -32,6 +32,7 @@ def verify_bearer_token(token: str | None) -> dict:
             settings.flightblender_write_scope,
             getattr(settings, "rid_display_provider_scope", "rid.display_provider"),
             getattr(settings, "rid_service_provider_scope", "rid.service_provider"),
+            getattr(settings, "geo_awareness_test_scope", "geo-awareness.test"),
         ]
         return {"scope": " ".join(scopes)}
 
@@ -102,3 +103,9 @@ WriteDep = Depends(require_scope(settings.flightblender_write_scope))
 # generic blender read/write scopes, matching the Django original.
 RIDDisplayProviderDep = Depends(require_scope(settings.rid_display_provider_scope))
 RIDServiceProviderDep = Depends(require_scope(settings.rid_service_provider_scope))
+
+# InterUSS geo-awareness test-harness scope (ED-269). The geo-awareness status,
+# geospatial data source lifecycle and map-query endpoints must require this
+# dedicated scope rather than the generic blender read/write scopes, matching
+# the Django original which guarded them with ``geo-awareness.test``.
+GeoAwarenessTestDep = Depends(require_scope(settings.geo_awareness_test_scope))

--- a/src/flight_blender/auth/jwt_bearer.py
+++ b/src/flight_blender/auth/jwt_bearer.py
@@ -24,8 +24,16 @@ def verify_bearer_token(token: str | None) -> dict:
     (development / test mode only).
     """
     if settings.bypass_auth_token_verification:
-        # Return a minimal payload with all scopes
-        return {"scope": f"{settings.flightblender_read_scope} {settings.flightblender_write_scope}"}
+        # Return a minimal payload with all scopes (dev / test mode), including
+        # the RID peer-USS interop scopes so the USS-to-USS endpoints are
+        # reachable without a real token.
+        scopes = [
+            settings.flightblender_read_scope,
+            settings.flightblender_write_scope,
+            getattr(settings, "rid_display_provider_scope", "rid.display_provider"),
+            getattr(settings, "rid_service_provider_scope", "rid.service_provider"),
+        ]
+        return {"scope": " ".join(scopes)}
 
     if not token:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing authentication token")
@@ -88,3 +96,9 @@ def require_scope(*required_scopes: str):
 # Convenient aliases
 ReadDep = Depends(require_scope(settings.flightblender_read_scope))
 WriteDep = Depends(require_scope(settings.flightblender_write_scope))
+
+# Remote-ID peer-USS interop scopes (ASTM F3411). The USS-to-USS RID data
+# exchange endpoints must require these RID-specific scopes rather than the
+# generic blender read/write scopes, matching the Django original.
+RIDDisplayProviderDep = Depends(require_scope(settings.rid_display_provider_scope))
+RIDServiceProviderDep = Depends(require_scope(settings.rid_service_provider_scope))

--- a/src/flight_blender/common/datetime_utils.py
+++ b/src/flight_blender/common/datetime_utils.py
@@ -1,0 +1,28 @@
+"""
+Shared datetime parsing utilities.
+"""
+
+from datetime import datetime, timezone
+
+
+def parse_iso_utc(value: str | int | float | object | None, fallback: datetime | None = None) -> datetime | None:
+    """Parse an ISO-8601 string or Unix timestamp into a timezone-aware UTC datetime.
+
+    Returns *fallback* (default ``None``) when *value* is ``None`` or unparseable.
+    """
+    if value is None:
+        return fallback
+    try:
+        if isinstance(value, (int, float)):
+            return datetime.fromtimestamp(value, tz=timezone.utc)
+        dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return fallback
+
+
+def ensure_utc(dt: datetime) -> datetime:
+    """Return *dt* as a timezone-aware UTC datetime (naive → assumed UTC)."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt

--- a/src/flight_blender/common/enums.py
+++ b/src/flight_blender/common/enums.py
@@ -62,6 +62,31 @@ class SurveillanceSensorMaintenance(str):
     UNPLANNED = "unplanned"
 
 
+# ── Operational-intent state groupings (ASTM F3548-21) ───────────────────────
+# Restored from the Django common/data_definitions.py (dropped in the FastAPI
+# migration) so conformance / flight-declaration / SCD logic share one typed
+# source of truth.
+
+# Op-intent states valid for coordination (Django [1, 2, 3, 4]).
+VALID_OPERATIONAL_INTENT_STATES: frozenset[OperationState] = frozenset(
+    {
+        OperationState.ACCEPTED,
+        OperationState.ACTIVATED,
+        OperationState.NONCONFORMING,
+        OperationState.CONTINGENT,
+    }
+)
+
+# Op-intent states where the operation is actively airborne (Django [2, 3, 4]).
+ACTIVE_OPERATIONAL_STATES: frozenset[OperationState] = frozenset(
+    {
+        OperationState.ACTIVATED,
+        OperationState.NONCONFORMING,
+        OperationState.CONTINGENT,
+    }
+)
+
+
 # Scope constants
 FLIGHTBLENDER_READ_SCOPE = "blender.read"
 FLIGHTBLENDER_WRITE_SCOPE = "blender.write"

--- a/src/flight_blender/common/geometry.py
+++ b/src/flight_blender/common/geometry.py
@@ -1,0 +1,43 @@
+"""
+Shared geometry utilities.
+"""
+
+
+def point_in_polygon(lon: float, lat: float, ring: list[tuple[float, float]]) -> bool:
+    """Return whether the point ``(lon, lat)`` lies inside *ring*.
+
+    Pure-Python ray-casting (even-odd rule).  *ring* is a list of
+    ``(lon, lat)`` tuples; the ring is treated as closed (the last vertex is
+    implicitly joined back to the first).
+    """
+    n = len(ring)
+    if n < 3:
+        return False
+    inside = False
+    j = n - 1
+    for i in range(n):
+        xi, yi = ring[i]
+        xj, yj = ring[j]
+        if ((yi > lat) != (yj > lat)) and (lon < (xj - xi) * (lat - yi) / ((yj - yi) or 1e-12) + xi):
+            inside = not inside
+        j = i
+    return inside
+
+
+def bounds_contains_point(bounds: str, lon: float, lat: float) -> bool:
+    """Return True if the comma-separated ``minx,miny,maxx,maxy`` bounds cover the point."""
+    try:
+        minx, miny, maxx, maxy = (float(x) for x in bounds.split(","))
+    except (ValueError, AttributeError):
+        return False
+    return minx <= lon <= maxx and miny <= lat <= maxy
+
+
+def compute_bounds(coordinates: list[list[float]]) -> str:
+    """Return ``"minx,miny,maxx,maxy"`` (7 dp) for a set of ``[lon, lat]`` pairs."""
+    if not coordinates:
+        return ""
+    lons = [c[0] for c in coordinates]
+    lats = [c[1] for c in coordinates]
+    bnd = (min(lons), min(lats), max(lons), max(lats))
+    return ",".join(f"{x:.7f}" for x in bnd)

--- a/src/flight_blender/common/redis_stream_operations.py
+++ b/src/flight_blender/common/redis_stream_operations.py
@@ -2,7 +2,7 @@
 Redis stream operations for air traffic data (migrated from common/redis_stream_operations.py).
 """
 
-from flight_blender.common.redis_client import get_redis
+from flight_blender.common.redis_client import get_async_redis, get_redis
 
 FLIGHT_OBSERVATION_KEY = "flight_blender_air_traffic"
 MAX_STREAM_LEN = 500
@@ -43,4 +43,25 @@ def read_all_observations(session_id: str | None = None, count: int = 500) -> li
 def read_latest_observation(session_id: str | None = None) -> dict | None:
     """Return the most-recent observation, optionally filtered by session_id."""
     observations = read_all_observations(session_id=session_id, count=500)
+    return observations[0] if observations else None
+
+
+# ── Async variants for use in async handlers (WebSocket, FastAPI endpoints) ──
+
+
+async def async_read_all_observations(session_id: str | None = None, count: int = 500) -> list[dict]:
+    """Async version of :func:`read_all_observations` for use in async handlers."""
+    r = get_async_redis()
+    entries = await r.xrevrange(FLIGHT_OBSERVATION_KEY, count=count)
+    result = []
+    for _entry_id, fields in entries:
+        if session_id and fields.get("session_id") != session_id:
+            continue
+        result.append(fields)
+    return result
+
+
+async def async_read_latest_observation(session_id: str | None = None) -> dict | None:
+    """Async version of :func:`read_latest_observation` for use in async handlers."""
+    observations = await async_read_all_observations(session_id=session_id, count=500)
     return observations[0] if observations else None

--- a/src/flight_blender/common/sync_engine.py
+++ b/src/flight_blender/common/sync_engine.py
@@ -1,0 +1,22 @@
+"""
+Synchronous SQLAlchemy engine singleton for Celery tasks.
+
+Celery workers run synchronous code, so they need a sync SQLAlchemy engine
+rather than the async engine configured in :mod:`flight_blender.database`.
+"""
+
+from functools import lru_cache
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+
+@lru_cache(maxsize=1)
+def get_sync_engine(database_url: str) -> Engine:
+    """Return a cached synchronous SQLAlchemy engine for *database_url*.
+
+    Translates the async database URL (``+aiosqlite`` / ``+asyncpg``) to the
+    corresponding sync dialect (plain ``sqlite`` / ``+psycopg2``).
+    """
+    sync_url = database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
+    return create_engine(sync_url)

--- a/src/flight_blender/config.py
+++ b/src/flight_blender/config.py
@@ -84,6 +84,11 @@ class Settings(BaseSettings):
     # ── Scopes ─────────────────────────────────────────────────────────────────
     flightblender_read_scope: str = "blender.read"
     flightblender_write_scope: str = "blender.write"
+    # Remote-ID peer-USS interop scopes (ASTM F3411). These guard the USS-to-USS
+    # RID data exchange and MUST stay distinct from the generic blender scopes —
+    # other USSs present these RID scopes, not the blender read/write scopes.
+    rid_display_provider_scope: str = "rid.display_provider"
+    rid_service_provider_scope: str = "rid.service_provider"
 
     # ── Plugin Engine Settings ─────────────────────────────────────────────────
     plugin_traffic_data_fuser: str = Field(

--- a/src/flight_blender/config.py
+++ b/src/flight_blender/config.py
@@ -55,6 +55,8 @@ class Settings(BaseSettings):
     dss_auth_url: str = Field(default="http://host.docker.internal:8085", alias="DSS_AUTH_URL")
     dss_auth_token_endpoint: str = Field(default="/auth/token", alias="DSS_AUTH_TOKEN_ENDPOINT")
     dss_self_audience: str = Field(default="localhost", alias="DSS_SELF_AUDIENCE")
+    dss_auth_audience: str = Field(default="", alias="DSS_AUTH_AUDIENCE")
+    dss_base_url: str = Field(default="http://host.docker.internal:8082", alias="DSS_BASE_URL")
     auth_dss_client_id: str = Field(default="", alias="AUTH_DSS_CLIENT_ID")
     auth_dss_client_secret: str = Field(default="", alias="AUTH_DSS_CLIENT_SECRET")
 

--- a/src/flight_blender/config.py
+++ b/src/flight_blender/config.py
@@ -89,6 +89,10 @@ class Settings(BaseSettings):
     # other USSs present these RID scopes, not the blender read/write scopes.
     rid_display_provider_scope: str = "rid.display_provider"
     rid_service_provider_scope: str = "rid.service_provider"
+    # InterUSS geo-awareness test-harness scope (ED-269). Guards the geo-awareness
+    # status, geospatial data source lifecycle and map-query endpoints — distinct
+    # from the generic blender scopes, matching the Django original.
+    geo_awareness_test_scope: str = "geo-awareness.test"
 
     # ── Plugin Engine Settings ─────────────────────────────────────────────────
     plugin_traffic_data_fuser: str = Field(

--- a/src/flight_blender/config.py
+++ b/src/flight_blender/config.py
@@ -61,6 +61,9 @@ class Settings(BaseSettings):
     # ── API Auth ───────────────────────────────────────────────────────────────
     bypass_auth_token_verification: bool = Field(default=False, alias="BYPASS_AUTH_TOKEN_VERIFICATION")
     auth_server_jwks_uri: str = Field(default="", alias="AUTH_SERVER_JWKS_URI")
+    # Expected JWT audience (Django's PASSPORT_AUDIENCE / API_IDENTIFIER). When set,
+    # inbound tokens must carry a matching ``aud`` claim or they are rejected.
+    auth_audience: str = Field(default="", alias="AUTH_AUDIENCE")
 
     # ── Celery ─────────────────────────────────────────────────────────────────
     celery_broker_url: str = Field(default="", alias="CELERY_BROKER_URL")

--- a/src/flight_blender/database.py
+++ b/src/flight_blender/database.py
@@ -15,6 +15,10 @@ engine = create_async_engine(
     settings.database_url,
     echo=settings.debug,
     future=True,
+    pool_size=5,
+    max_overflow=10,
+    pool_recycle=3600,
+    pool_pre_ping=True,
 )
 
 AsyncSessionLocal = async_sessionmaker(
@@ -31,7 +35,11 @@ class Base(DeclarativeBase):
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
-    """FastAPI dependency: yields an async database session."""
+    """FastAPI dependency: yields an async database session.
+
+    The session is committed automatically after the handler returns
+    (unless an exception occurred, in which case it is rolled back).
+    """
     async with AsyncSessionLocal() as session:
         try:
             yield session

--- a/src/flight_blender/main.py
+++ b/src/flight_blender/main.py
@@ -50,9 +50,14 @@ def create_app() -> FastAPI:
     if not settings.debug:
         app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.allowed_hosts)
 
+    # CORS: never combine allow_credentials=True with allow_origins=["*"] —
+    # browsers reject this per the CORS spec.  In debug mode we allow the
+    # common local dev origins; in production the operator must configure
+    # ALLOWED_ORIGINS (falls back to ALLOWED_HOSTS for backward compat).
+    origins = ["http://localhost:3000", "http://localhost:8080", "http://127.0.0.1:3000"] if settings.debug else settings.allowed_hosts
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"] if settings.debug else settings.allowed_hosts,
+        allow_origins=origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/src/flight_blender/main.py
+++ b/src/flight_blender/main.py
@@ -65,6 +65,9 @@ def create_app() -> FastAPI:
     app.include_router(constraint.router, prefix="/constraint_ops", tags=["Constraints"])
     app.include_router(rid.router, prefix="/rid", tags=["Remote ID"])
     app.include_router(scd.router, prefix="/scd", tags=["SCD"])
+    # Peer-USS interop: Django served these at ``/uss``. Mount there for
+    # interop parity with other USSs and keep ``/uss_ops`` as a back-compat alias.
+    app.include_router(uss.router, prefix="/uss", tags=["USS Operations"])
     app.include_router(uss.router, prefix="/uss_ops", tags=["USS Operations"])
     app.include_router(utm_adapter.router, prefix="/utm_adapter", tags=["UTM Adapter"])
     app.include_router(surveillance.router, prefix="/surveillance_monitoring_ops", tags=["Surveillance"])

--- a/src/flight_blender/models/constraint.py
+++ b/src/flight_blender/models/constraint.py
@@ -3,7 +3,7 @@ SQLAlchemy models for constraint operations.
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, DateTime, Float, ForeignKey, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -35,8 +35,8 @@ class ConstraintReference(Base):
     manager: Mapped[str | None] = mapped_column(String(256), nullable=True)
     uss_base_url: Mapped[str] = mapped_column(String(256), default="", nullable=False)
     version: Mapped[str] = mapped_column(String(256), default="", nullable=False)
-    time_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
-    time_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
+    time_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    time_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     is_live: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
@@ -50,8 +50,8 @@ class CompositeConstraint(Base):
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     declaration_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("flight_declaration.id", ondelete="CASCADE"), nullable=False)
     bounds: Mapped[str] = mapped_column(String(140), nullable=False)
-    start_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
-    end_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
+    start_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    end_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     alt_max: Mapped[float] = mapped_column(Float, nullable=False)
     alt_min: Mapped[float] = mapped_column(Float, nullable=False)
     constraint_reference_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("constraint_reference.id", ondelete="CASCADE"), nullable=False)

--- a/src/flight_blender/models/flight_declaration.py
+++ b/src/flight_blender/models/flight_declaration.py
@@ -3,7 +3,7 @@ SQLAlchemy models for flight declaration operations.
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -25,8 +25,8 @@ class FlightDeclaration(Base):
     submitted_by: Mapped[str | None] = mapped_column(String(254), nullable=True)
     approved_by: Mapped[str | None] = mapped_column(String(254), nullable=True)
     latest_telemetry_datetime: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    start_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
-    end_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
+    start_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    end_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     is_approved: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
@@ -73,8 +73,8 @@ class FlightOperationalIntentReference(Base):
     uss_base_url: Mapped[str] = mapped_column(String(256), nullable=False)
     version: Mapped[str] = mapped_column(String(256), nullable=False)
     state: Mapped[str] = mapped_column(String(40), nullable=False)
-    time_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
-    time_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
+    time_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    time_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     subscription_id: Mapped[str] = mapped_column(String(256), nullable=False)
     is_live: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/src/flight_blender/models/flight_feed.py
+++ b/src/flight_blender/models/flight_feed.py
@@ -29,7 +29,7 @@ class FlightObservation(Base):
     __tablename__ = "flight_feed_observation"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    session_id: Mapped[uuid.UUID | None] = mapped_column(nullable=True)
+    session_id: Mapped[uuid.UUID | None] = mapped_column(nullable=True, index=True)
     latitude_dd: Mapped[float] = mapped_column(Float, nullable=False)
     longitude_dd: Mapped[float] = mapped_column(Float, nullable=False)
     altitude_mm: Mapped[float] = mapped_column(Float, nullable=False)

--- a/src/flight_blender/models/geo_fence.py
+++ b/src/flight_blender/models/geo_fence.py
@@ -3,7 +3,7 @@ SQLAlchemy models for geo fence operations.
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, DateTime, Integer, Numeric, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -25,8 +25,8 @@ class GeoFence(Base):
     status: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     message: Mapped[str | None] = mapped_column(String(140), nullable=True)
     is_test_dataset: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    start_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
-    end_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now)
+    start_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    end_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 

--- a/src/flight_blender/models/notification.py
+++ b/src/flight_blender/models/notification.py
@@ -15,7 +15,8 @@ class OperatorRIDNotification(Base):
     __tablename__ = "operator_rid_notification"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    session_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    # Django parity: ``session_id`` is ``blank=True, null=True`` (nullable).
+    session_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
     message: Mapped[str] = mapped_column(Text, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     flight_declaration_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("flight_declaration.id", ondelete="SET NULL"), nullable=True)

--- a/src/flight_blender/models/rid.py
+++ b/src/flight_blender/models/rid.py
@@ -15,13 +15,19 @@ class ISASubscription(Base):
     __tablename__ = "rid_isa_subscription"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    subscription_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    # Django: db_index=True
+    subscription_id: Mapped[str] = mapped_column(String(256), nullable=False, index=True)
     view: Mapped[str] = mapped_column(String(256), nullable=False)
     flight_details: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
     end_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    view_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    # Django stores ``view_hash`` as IntegerField(null=True, db_index=True). The
+    # FastAPI ingestion path computes a *string* SHA-256 digest of the view box,
+    # so this stays a String (documented deviation from Django's integer type)
+    # but matches Django's nullability and index.
+    view_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
     is_simulated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    # Django: db_index=True
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), index=True)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
 
@@ -35,5 +41,6 @@ class RIDFlightDetail(Base):
     auth_data: Mapped[str | None] = mapped_column(Text, nullable=True)
     uas_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     eu_classification: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    # Django: db_index=True
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), index=True)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/src/flight_blender/routers/daa.py
+++ b/src/flight_blender/routers/daa.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,40 +14,32 @@ from flight_blender.models.daa import DAAAlert, DAAIncidentLog
 router = APIRouter()
 
 
-def _parse_iso_date(value: str, field: str) -> datetime:
-    """Parse an ISO-8601 datetime filter, returning 422 on malformed input.
-
-    The original port silently swallowed ``ValueError`` and dropped the filter,
-    so a client passing a bad date got unfiltered results with no error signal.
-    """
-    try:
-        return datetime.fromisoformat(value)
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=f"Invalid ISO-8601 datetime for {field}: {value!r}",
-        ) from exc
-
-
 def _filter_incident_query(
     query: Select,
     event_type: str | None,
     alert_level: int | None,
     alert_id: str | None,
-    start_date: str | None,
-    end_date: str | None,
+    start_date: datetime | None,
+    end_date: datetime | None,
 ) -> Select:
-    """Apply optional server-side filters to a DAAIncidentLog query."""
+    """Apply optional server-side filters to a DAAIncidentLog query.
+
+    Date filters are parsed at the API boundary: the route declares the
+    ``start_date``/``end_date`` query params as ``datetime``, so FastAPI/Pydantic
+    coerces them and returns ``422`` on malformed input before the handler runs.
+    This helper therefore receives already-parsed ``datetime`` objects (or
+    ``None``) and only applies the filter.
+    """
     if event_type:
         query = query.where(DAAIncidentLog.event_type == event_type)
     if alert_level is not None:
         query = query.where(DAAIncidentLog.alert_level == alert_level)
     if alert_id:
         query = query.where(DAAIncidentLog.alert_id == alert_id)
-    if start_date:
-        query = query.where(DAAIncidentLog.created_at >= _parse_iso_date(start_date, "start_date"))
-    if end_date:
-        query = query.where(DAAIncidentLog.created_at <= _parse_iso_date(end_date, "end_date"))
+    if start_date is not None:
+        query = query.where(DAAIncidentLog.created_at >= start_date)
+    if end_date is not None:
+        query = query.where(DAAIncidentLog.created_at <= end_date)
     return query
 
 
@@ -79,8 +71,8 @@ async def get_active_daa_alerts(db: AsyncSession = Depends(get_db)) -> list[dict
 async def get_daa_incident_logs(
     event_type: str | None = Query(default=None),
     alert_level: int | None = Query(default=None),
-    start_date: str | None = Query(default=None),
-    end_date: str | None = Query(default=None),
+    start_date: datetime | None = Query(default=None),
+    end_date: datetime | None = Query(default=None),
     alert_id: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
 ) -> list[dict[str, Any]]:

--- a/src/flight_blender/routers/daa.py
+++ b/src/flight_blender/routers/daa.py
@@ -24,7 +24,7 @@ def _parse_iso_date(value: str, field: str) -> datetime:
         return datetime.fromisoformat(value)
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Invalid ISO-8601 datetime for {field}: {value!r}",
         ) from exc
 

--- a/src/flight_blender/routers/daa.py
+++ b/src/flight_blender/routers/daa.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,6 +12,21 @@ from flight_blender.database import get_db
 from flight_blender.models.daa import DAAAlert, DAAIncidentLog
 
 router = APIRouter()
+
+
+def _parse_iso_date(value: str, field: str) -> datetime:
+    """Parse an ISO-8601 datetime filter, returning 422 on malformed input.
+
+    The original port silently swallowed ``ValueError`` and dropped the filter,
+    so a client passing a bad date got unfiltered results with no error signal.
+    """
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid ISO-8601 datetime for {field}: {value!r}",
+        ) from exc
 
 
 def _filter_incident_query(
@@ -30,15 +45,9 @@ def _filter_incident_query(
     if alert_id:
         query = query.where(DAAIncidentLog.alert_id == alert_id)
     if start_date:
-        try:
-            query = query.where(DAAIncidentLog.created_at >= datetime.fromisoformat(start_date))
-        except ValueError:
-            pass
+        query = query.where(DAAIncidentLog.created_at >= _parse_iso_date(start_date, "start_date"))
     if end_date:
-        try:
-            query = query.where(DAAIncidentLog.created_at <= datetime.fromisoformat(end_date))
-        except ValueError:
-            pass
+        query = query.where(DAAIncidentLog.created_at <= _parse_iso_date(end_date, "end_date"))
     return query
 
 

--- a/src/flight_blender/routers/flight_declaration.py
+++ b/src/flight_blender/routers/flight_declaration.py
@@ -370,17 +370,27 @@ async def bulk_create_flight_declarations(payloads: list[FlightDeclarationFullRe
     settings = get_settings()
     default_state = 0 if settings.ussp_network_enabled else 1
 
-    # Optimistic bulk creation, mirroring the Django bulk endpoint: each
-    # declaration is created with is_approved=True / state=default_state; the
-    # full strategic intersection check is applied on the single-create paths.
+    # Each declaration runs the same strategic deconfliction as the single-create
+    # path: a conflict (or engine error) fails closed and is not approved.
     for payload in payloads:
         try:
             fields = _build_declaration_from_full_request(payload)
             fields["state"] = default_state
-            fields["is_approved"] = True
+            is_approved, deconf_state = await _run_deconfliction(
+                payload.flight_declaration_geo_json,
+                fields["start_datetime"],
+                fields["end_datetime"],
+                db=db,
+                bounds=fields["bounds"],
+                type_of_operation=fields["type_of_operation"],
+            )
+            fields["is_approved"] = is_approved
+            fields["state"] = deconf_state
             decl = FlightDeclaration(**fields)
             db.add(decl)
             await db.flush()
+            await db.refresh(decl)
+            _maybe_submit_to_dss(decl.id, is_approved, deconf_state)
             results.append(BulkFlightDeclarationResult(id=decl.id, message="Created", success=True))
             submitted += 1
         except Exception as exc:

--- a/src/flight_blender/routers/flight_declaration.py
+++ b/src/flight_blender/routers/flight_declaration.py
@@ -512,15 +512,28 @@ async def set_operational_intents_bulk(payloads: list[OperationalIntentIngestReq
     settings = get_settings()
     default_state = 0 if settings.ussp_network_enabled else 1
 
-    # Optimistic bulk creation, mirroring the Django bulk endpoint (the strategic
-    # intersection check is applied on the single-create paths).
+    # Each op-intent runs the same strategic deconfliction as the single-create
+    # path: a conflict (or engine error) fails closed and is not approved.
     for payload in payloads:
         try:
             fields = _build_declaration_from_op_intent(payload.model_dump(), default_state=default_state)
-            fields["is_approved"] = True
+            geo_json_str = fields.get("flight_declaration_raw_geojson")
+            geo_json = json.loads(geo_json_str) if geo_json_str else None
+            is_approved, deconf_state = await _run_deconfliction(
+                geo_json,
+                fields["start_datetime"],
+                fields["end_datetime"],
+                db=db,
+                bounds=fields["bounds"],
+                type_of_operation=fields["type_of_operation"],
+            )
+            fields["is_approved"] = is_approved
+            fields["state"] = deconf_state
             decl = FlightDeclaration(**fields)
             db.add(decl)
             await db.flush()
+            await db.refresh(decl)
+            _maybe_submit_to_dss(decl.id, is_approved, deconf_state)
             results.append(BulkFlightDeclarationResult(id=decl.id, message="Created", success=True))
             submitted += 1
         except Exception as exc:

--- a/src/flight_blender/routers/flight_declaration.py
+++ b/src/flight_blender/routers/flight_declaration.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from flight_blender.auth import ReadDep, WriteDep
+from flight_blender.common.enums import OperationState
 from flight_blender.common.plugin_loader import load_plugin
 from flight_blender.config import get_settings
 from flight_blender.database import get_db
@@ -148,47 +149,60 @@ async def _run_deconfliction(
     type_of_operation: int = 0,
     exclude_id: uuid.UUID | None = None,
 ) -> tuple[bool, int]:
-    """Pre-fetch spatial data from DB then run the configured deconfliction engine."""
+    """Pre-fetch spatial data from DB then run the configured deconfliction engine.
+
+    Strategic deconfliction is safety critical and *fails closed*: any error
+    building inputs or running the engine results in the operation NOT being
+    approved (state Rejected), rather than being silently accepted.
+    """
     settings = get_settings()
-
-    # Pre-fetch active geofences overlapping the time window
-    fence_result = await db.execute(
-        select(GeoFence).where(
-            GeoFence.status == 1,
-            GeoFence.start_datetime <= end_datetime,
-            GeoFence.end_datetime >= start_datetime,
+    try:
+        # Pre-fetch active geofences overlapping the time window
+        fence_result = await db.execute(
+            select(GeoFence).where(
+                GeoFence.status == 1,
+                GeoFence.start_datetime <= end_datetime,
+                GeoFence.end_datetime >= start_datetime,
+            )
         )
-    )
-    fences = fence_result.scalars().all()
-    prefetched_fences = [{"id": str(f.id), "bounds": f.bounds} for f in fences]
+        fences = fence_result.scalars().all()
+        prefetched_fences = [{"id": str(f.id), "bounds": f.bounds} for f in fences]
 
-    # Pre-fetch active flight declarations overlapping the time window
-    decl_query = select(FlightDeclaration).where(
-        FlightDeclaration.state.in_(_ACTIVE_STATES),
-        FlightDeclaration.start_datetime <= end_datetime,
-        FlightDeclaration.end_datetime >= start_datetime,
-    )
-    if exclude_id is not None:
-        decl_query = decl_query.where(FlightDeclaration.id != exclude_id)
-    decl_result = await db.execute(decl_query)
-    declarations = decl_result.scalars().all()
-    prefetched_declarations = [{"id": str(d.id), "bounds": d.bounds} for d in declarations]
+        # Pre-fetch active flight declarations overlapping the time window
+        decl_query = select(FlightDeclaration).where(
+            FlightDeclaration.state.in_(_ACTIVE_STATES),
+            FlightDeclaration.start_datetime <= end_datetime,
+            FlightDeclaration.end_datetime >= start_datetime,
+        )
+        if exclude_id is not None:
+            decl_query = decl_query.where(FlightDeclaration.id != exclude_id)
+        decl_result = await db.execute(decl_query)
+        declarations = decl_result.scalars().all()
+        prefetched_declarations = [{"id": str(d.id), "bounds": d.bounds} for d in declarations]
 
-    engine_cls = load_plugin(settings.plugin_deconfliction_engine, expected_protocol=DeconflictionEngine)
-    engine = engine_cls()
-    req = DeconflictionRequest(
-        start_datetime=start_datetime.isoformat(),
-        end_datetime=end_datetime.isoformat(),
-        flight_declaration_geo_json=geo_json,
-        view_box=_view_box_from_bounds(bounds),
-        ussp_network_enabled=settings.ussp_network_enabled,
-        type_of_operation=type_of_operation,
-        priority=0,
-        prefetched_fences=prefetched_fences,
-        prefetched_declarations=prefetched_declarations,
-    )
-    result = engine.check_deconfliction(req)
-    return result.is_approved, result.declaration_state
+        engine_cls = load_plugin(settings.plugin_deconfliction_engine, expected_protocol=DeconflictionEngine)
+        engine = engine_cls()
+        # Bounding-box (R-tree) deconfliction — a faithful port of the Django
+        # DefaultDeconflictionEngine create-path. The full 4D volume-mode check
+        # (deconflict_operational_intent) is exercised directly by the engine
+        # unit tests and used by the SCD flight-planning endpoint.
+        req = DeconflictionRequest(
+            start_datetime=start_datetime.isoformat(),
+            end_datetime=end_datetime.isoformat(),
+            flight_declaration_geo_json=geo_json,
+            view_box=_view_box_from_bounds(bounds),
+            ussp_network_enabled=int(settings.ussp_network_enabled),
+            type_of_operation=type_of_operation,
+            priority=0,
+            prefetched_fences=prefetched_fences,
+            prefetched_declarations=prefetched_declarations,
+        )
+        result = engine.check_deconfliction(req)
+        return result.is_approved, result.declaration_state
+    except Exception as exc:
+        # Fail closed: a deconfliction failure must never auto-approve an operation.
+        logger.error("Deconfliction engine error; failing closed (not approving): {}", exc)
+        return False, int(OperationState.REJECTED)
 
 
 async def _get_declaration_or_404(declaration_id: uuid.UUID, db: AsyncSession) -> FlightDeclaration:
@@ -196,6 +210,21 @@ async def _get_declaration_or_404(declaration_id: uuid.UUID, db: AsyncSession) -
     if not obj:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Flight declaration not found")
     return obj
+
+
+def _maybe_submit_to_dss(declaration_id: uuid.UUID, is_approved: bool, declaration_state: int) -> None:
+    """Submit an approved operation to the DSS when the USSP network is enabled.
+
+    Mirrors the Django acceptance path
+    (``flight_declaration_operations/views.py``): a clear deconfliction result
+    with the USSP network enabled leaves the operation Processing (state 0) and
+    queues an async DSS submission, gated additionally by ``AUTO_SUBMIT_TO_DSS``.
+    With the network disabled the operation is Accepted locally (state 1) and no
+    submission is made.
+    """
+    settings = get_settings()
+    if is_approved and declaration_state == int(OperationState.NOT_SUBMITTED) and settings.ussp_network_enabled and settings.auto_submit_to_dss:
+        submit_flight_declaration_to_dss_async.delay(str(declaration_id))
 
 
 # ── CRUD ────────────────────────────────────────────────────────────────────────
@@ -341,20 +370,14 @@ async def bulk_create_flight_declarations(payloads: list[FlightDeclarationFullRe
     settings = get_settings()
     default_state = 0 if settings.ussp_network_enabled else 1
 
+    # Optimistic bulk creation, mirroring the Django bulk endpoint: each
+    # declaration is created with is_approved=True / state=default_state; the
+    # full strategic intersection check is applied on the single-create paths.
     for payload in payloads:
         try:
             fields = _build_declaration_from_full_request(payload)
             fields["state"] = default_state
-            is_approved, deconf_state = await _run_deconfliction(
-                payload.flight_declaration_geo_json,
-                fields["start_datetime"],
-                fields["end_datetime"],
-                db=db,
-                bounds=fields["bounds"],
-                type_of_operation=fields["type_of_operation"],
-            )
-            fields["is_approved"] = is_approved
-            fields["state"] = deconf_state
+            fields["is_approved"] = True
             decl = FlightDeclaration(**fields)
             db.add(decl)
             await db.flush()
@@ -391,6 +414,7 @@ async def set_flight_declaration(payload: FlightDeclarationFullRequest, db: Asyn
     db.add(decl)
     await db.flush()
     await db.refresh(decl)
+    _maybe_submit_to_dss(decl.id, is_approved, deconf_state)
     return FlightDeclarationCreateResponse(id=decl.id, message="Flight declaration created", is_approved=decl.is_approved, state=decl.state)
 
 
@@ -462,6 +486,7 @@ async def set_operational_intent(payload: OperationalIntentIngestRequest, db: As
     db.add(decl)
     await db.flush()
     await db.refresh(decl)
+    _maybe_submit_to_dss(decl.id, is_approved, deconf_state)
     return FlightDeclarationCreateResponse(
         id=decl.id, message="Flight declaration created via operational intent", is_approved=decl.is_approved, state=decl.state
     )
@@ -477,21 +502,12 @@ async def set_operational_intents_bulk(payloads: list[OperationalIntentIngestReq
     settings = get_settings()
     default_state = 0 if settings.ussp_network_enabled else 1
 
+    # Optimistic bulk creation, mirroring the Django bulk endpoint (the strategic
+    # intersection check is applied on the single-create paths).
     for payload in payloads:
         try:
             fields = _build_declaration_from_op_intent(payload.model_dump(), default_state=default_state)
-            geo_json_str = fields.get("flight_declaration_raw_geojson")
-            geo_json = json.loads(geo_json_str) if geo_json_str else None
-            is_approved, deconf_state = await _run_deconfliction(
-                geo_json,
-                fields["start_datetime"],
-                fields["end_datetime"],
-                db=db,
-                bounds=fields["bounds"],
-                type_of_operation=fields["type_of_operation"],
-            )
-            fields["is_approved"] = is_approved
-            fields["state"] = deconf_state
+            fields["is_approved"] = True
             decl = FlightDeclaration(**fields)
             db.add(decl)
             await db.flush()

--- a/src/flight_blender/routers/flight_declaration.py
+++ b/src/flight_blender/routers/flight_declaration.py
@@ -12,7 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from flight_blender.auth import ReadDep, WriteDep
-from flight_blender.common.enums import OperationState
+from flight_blender.common.enums import OperationState, VALID_OPERATIONAL_INTENT_STATES
 from flight_blender.common.plugin_loader import load_plugin
 from flight_blender.config import get_settings
 from flight_blender.database import get_db
@@ -41,17 +41,7 @@ router = APIRouter()
 # ── Shared helpers ────────────────────────────────────────────────────────────
 
 
-def _parse_utc_dt(value: str | int | float | None, fallback: datetime) -> datetime:
-    """Parse a datetime from an ISO string or Unix timestamp, defaulting to *fallback*."""
-    if value is None:
-        return fallback
-    try:
-        if isinstance(value, (int, float)):
-            return datetime.fromtimestamp(value, tz=timezone.utc)
-        parsed = datetime.fromisoformat(str(value))
-        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
-    except (ValueError, TypeError):
-        return fallback
+from flight_blender.common.datetime_utils import parse_iso_utc as _parse_utc_dt
 
 
 def _safe_int(value: object, default: int) -> int:
@@ -137,7 +127,7 @@ def _view_box_from_bounds(bounds_json: str) -> list[float]:
         return []
 
 
-_ACTIVE_STATES = [1, 2, 3, 4]  # Accepted, Activated, NonConforming, Contingent
+_ACTIVE_STATES = list(VALID_OPERATIONAL_INTENT_STATES)
 
 
 async def _run_deconfliction(

--- a/src/flight_blender/routers/flight_feed.py
+++ b/src/flight_blender/routers/flight_feed.py
@@ -23,6 +23,7 @@ from flight_blender.schemas.flight_feed import (
     SingleObservation,
     TelemetryObservation,
 )
+from flight_blender.tasks.flight_declaration import send_operational_update_message
 from flight_blender.tasks.flight_feed import bulk_write_incoming_air_traffic_data, write_incoming_air_traffic_data
 
 router = APIRouter()
@@ -86,6 +87,11 @@ async def set_air_traffic(payload: BulkObservationRequest, session_id: uuid.UUID
     """
     observations = [{**obs.model_dump(), "session_id": str(session_id)} for obs in payload.observations]
     bulk_write_incoming_air_traffic_data.delay(observations)
+    send_operational_update_message.delay(
+        str(session_id),
+        f"{len(observations)} air traffic observation(s) ingested",
+        "info",
+    )
     return {"message": f"{len(observations)} observation(s) queued for processing"}
 
 
@@ -94,6 +100,11 @@ async def bulk_set_air_traffic(payload: BulkObservationRequest, session_id: uuid
     """Ingest multiple air traffic observations via Celery task."""
     observations = [{**obs.model_dump(), "session_id": str(session_id)} for obs in payload.observations]
     bulk_write_incoming_air_traffic_data.delay(observations)
+    send_operational_update_message.delay(
+        str(session_id),
+        f"{len(observations)} air traffic observation(s) ingested",
+        "info",
+    )
     return {"message": f"{len(observations)} observations queued for processing"}
 
 

--- a/src/flight_blender/routers/flight_feed.py
+++ b/src/flight_blender/routers/flight_feed.py
@@ -161,7 +161,7 @@ async def set_signed_telemetry(payload: TelemetryObservation, request: Request, 
     active_keys = key_result.scalars().all()
 
     if active_keys:
-        public_keys = fetch_public_keys_from_db_rows(active_keys)
+        public_keys = await fetch_public_keys_from_db_rows(active_keys)
         body = await request.body()
         verified = await verify_signed_request(
             method=request.method,

--- a/src/flight_blender/routers/geo_fence.py
+++ b/src/flight_blender/routers/geo_fence.py
@@ -39,28 +39,11 @@ from flight_blender.tasks.geo_fence import (
 router = APIRouter()
 
 
-def _compute_bounds(flat_coords: list[list[float]]) -> str:
-    """Return a comma-separated ``"minx,miny,maxx,maxy"`` bounds string.
-
-    Matches the Django ``unary_union(...).bounds`` formatting and the
-    ``write_geo_zone`` task path, so all GeoFence rows share one bounds format.
-    """
-    if not flat_coords:
-        return ""
-    lons = [pt[0] for pt in flat_coords]
-    lats = [pt[1] for pt in flat_coords]
-    return f"{min(lons):.7f},{min(lats):.7f},{max(lons):.7f},{max(lats):.7f}"
-
-
 def _parse_fence_dt(props: dict[str, Any], key: str, fallback: datetime) -> datetime:
     """Parse a datetime string from props or return the fallback."""
-    try:
-        dt = datetime.fromisoformat(props[key])
-    except (KeyError, ValueError):
-        dt = fallback
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt
+    from flight_blender.common.datetime_utils import parse_iso_utc
+
+    return parse_iso_utc(props.get(key), fallback=fallback) or fallback
 
 
 async def _get_fence_or_404(fence_id: uuid.UUID, db: AsyncSession, *, include_test: bool = True) -> GeoFence:
@@ -142,7 +125,9 @@ def _parse_geojson_fence(geojson: dict[str, Any]) -> dict[str, Any]:
     geometry = features[0].get("geometry") or {}
 
     flat_coords = [pt for ring in geometry.get("coordinates", [[]]) for pt in ring]
-    bounds = _compute_bounds(flat_coords)
+    from flight_blender.common.geometry import compute_bounds
+
+    bounds = compute_bounds(flat_coords)
 
     now = datetime.now(timezone.utc)
     start_dt = _parse_fence_dt(props, "start_time", now)
@@ -199,43 +184,19 @@ async def geo_awareness_status():
     return GeoAwarenessStatusResponse(status="Ready", api_version="latest")
 
 
-def _point_in_ring(lon: float, lat: float, ring: list[list[float]]) -> bool:
-    """Ray-casting point-in-polygon test for a single ``[lon, lat]`` ring."""
-    inside = False
-    n = len(ring)
-    if n < 3:
-        return False
-    j = n - 1
-    for i in range(n):
-        xi, yi = ring[i][0], ring[i][1]
-        xj, yj = ring[j][0], ring[j][1]
-        if ((yi > lat) != (yj > lat)) and (lon < (xj - xi) * (lat - yi) / ((yj - yi) or 1e-12) + xi):
-            inside = not inside
-        j = i
-    return inside
-
-
-def _bounds_contains_point(bounds: str, lon: float, lat: float) -> bool:
-    """Return True if the comma-separated ``minx,miny,maxx,maxy`` bounds cover the point."""
-    try:
-        minx, miny, maxx, maxy = (float(x) for x in bounds.split(","))
-    except (ValueError, AttributeError):
-        return False
-    return minx <= lon <= maxx and miny <= lat <= maxy
-
-
 def _geozone_covers_point(fence: GeoFence, lon: float, lat: float) -> bool:
     """Point membership: try the stored geometry ring, fall back to the bbox."""
+    from flight_blender.common.geometry import bounds_contains_point, compute_bounds, point_in_polygon
     from flight_blender.tasks.geo_fence import feature_to_coordinates
 
     if fence.geozone:
         try:
             ring = feature_to_coordinates(json.loads(fence.geozone))
             if ring:
-                return _point_in_ring(lon, lat, ring)
+                return point_in_polygon(lon, lat, [(p[0], p[1]) for p in ring])
         except (TypeError, ValueError):
             pass
-    return _bounds_contains_point(fence.bounds or "", lon, lat)
+    return bounds_contains_point(fence.bounds or "", lon, lat)
 
 
 @router.post("/geo_awareness/map/queries", response_model=GeoZoneChecksResponse, dependencies=[GeoAwarenessTestDep])

--- a/src/flight_blender/routers/geo_fence.py
+++ b/src/flight_blender/routers/geo_fence.py
@@ -12,29 +12,44 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
-from flight_blender.auth import ReadDep, WriteDep
+from flight_blender.auth import GeoAwarenessTestDep, ReadDep, WriteDep
 from flight_blender.database import get_db
 from flight_blender.models.geo_fence import GeoFence
 from flight_blender.schemas.geo_fence import (
     GeoAwarenessStatusResponse,
+    GeoAwarenessTestStatus,
     GeoFenceCreate,
     GeoFenceListResponse,
     GeoFenceResponse,
     GeoFenceUpdate,
+    GeoZoneCheckResult,
+    GeoZoneChecksResponse,
     GeoZoneQueryRequest,
+    GeoZoneSourceRequest,
 )
-from flight_blender.tasks.geo_fence import download_geozone_source, write_geo_zone
+from flight_blender.tasks.geo_fence import (
+    delete_geozone_source_status,
+    download_geozone_source,
+    get_geozone_source_status,
+    set_geozone_source_status,
+    validate_geo_zone,
+    write_geo_zone,
+)
 
 router = APIRouter()
 
 
 def _compute_bounds(flat_coords: list[list[float]]) -> str:
-    """Return a JSON bounds string from a flat list of [lon, lat] coordinate pairs."""
+    """Return a comma-separated ``"minx,miny,maxx,maxy"`` bounds string.
+
+    Matches the Django ``unary_union(...).bounds`` formatting and the
+    ``write_geo_zone`` task path, so all GeoFence rows share one bounds format.
+    """
     if not flat_coords:
-        return "{}"
+        return ""
     lons = [pt[0] for pt in flat_coords]
     lats = [pt[1] for pt in flat_coords]
-    return json.dumps({"minx": min(lons), "miny": min(lats), "maxx": max(lons), "maxy": max(lats)})
+    return f"{min(lons):.7f},{min(lats):.7f},{max(lons):.7f},{max(lats):.7f}"
 
 
 def _parse_fence_dt(props: dict[str, Any], key: str, fallback: datetime) -> datetime:
@@ -48,9 +63,9 @@ def _parse_fence_dt(props: dict[str, Any], key: str, fallback: datetime) -> date
     return dt
 
 
-async def _get_fence_or_404(fence_id: uuid.UUID, db: AsyncSession) -> GeoFence:
+async def _get_fence_or_404(fence_id: uuid.UUID, db: AsyncSession, *, include_test: bool = True) -> GeoFence:
     obj = await db.get(GeoFence, fence_id)
-    if not obj:
+    if not obj or (not include_test and obj.is_test_dataset):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Geo fence not found")
     return obj
 
@@ -65,9 +80,12 @@ async def list_geo_fences(
     db: AsyncSession = Depends(get_db),
 ):
     offset = (page - 1) * page_size
-    count_result = await db.execute(select(func.count()).select_from(GeoFence))
+    # Django ``GeoFenceList`` filters out test datasets so the InterUSS test
+    # harness data never leaks into the operational listing.
+    base = select(GeoFence).where(GeoFence.is_test_dataset.is_(False))
+    count_result = await db.execute(select(func.count()).select_from(base.subquery()))
     total = count_result.scalar_one()
-    result = await db.execute(select(GeoFence).order_by(GeoFence.created_at.desc()).offset(offset).limit(page_size))
+    result = await db.execute(base.order_by(GeoFence.created_at.desc()).offset(offset).limit(page_size))
     return GeoFenceListResponse(count=total, results=result.scalars().all())
 
 
@@ -82,7 +100,8 @@ async def create_geo_fence(payload: GeoFenceCreate, db: AsyncSession = Depends(g
 
 @router.get("/geo_fence/{fence_id}", response_model=GeoFenceResponse, dependencies=[ReadDep])
 async def get_geo_fence(fence_id: uuid.UUID = Path(...), db: AsyncSession = Depends(get_db)):
-    return await _get_fence_or_404(fence_id, db)
+    # Django ``GeoFenceDetail`` hides test datasets (404 for them).
+    return await _get_fence_or_404(fence_id, db, include_test=False)
 
 
 @router.put("/geo_fence/{fence_id}", response_model=GeoFenceResponse, dependencies=[WriteDep])
@@ -157,88 +176,135 @@ async def set_geo_fence_put(geojson: dict[str, Any] = Body(...), db: AsyncSessio
 
 @router.post("/set_geozone", dependencies=[WriteDep])
 async def set_geozone(payload: dict, db: AsyncSession = Depends(get_db)):
-    """Accept an ED-269 GeoZone payload and queue async processing."""
+    """Accept an ED-269 GeoZone payload, validate it, and queue async processing.
+
+    Restores the Django request-time ``validate_geo_zone`` gate: an invalid or
+    description-less GeoZone is rejected with 400 rather than silently queued.
+    """
+    if not validate_geo_zone(payload):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A valid geozone object with a description is necessary in the body of the request",
+        )
     write_geo_zone.delay(payload)
-    return {"message": "GeoZone queued for processing"}
+    return {"message": "GeoZone queued for processing", "id": str(uuid.uuid4())}
 
 
-# ── Geo Awareness (test harness) ───────────────────────────────────────────────
+# ── Geo Awareness (InterUSS ED-269 test harness) ───────────────────────────────
 
 
-@router.get("/geo_awareness/status", response_model=GeoAwarenessStatusResponse, dependencies=[ReadDep])
+@router.get("/geo_awareness/status", response_model=GeoAwarenessStatusResponse, dependencies=[GeoAwarenessTestDep])
 async def geo_awareness_status():
-    return GeoAwarenessStatusResponse(result="Ready", message="Geo awareness service is operational")
+    """InterUSS geo-awareness test-harness status (guarded by geo-awareness.test)."""
+    return GeoAwarenessStatusResponse(status="Ready", api_version="latest")
 
 
-def _extract_view_box(volumes: list[dict]) -> list[float] | None:
-    """Return [min_lon, min_lat, max_lon, max_lat] from query volumes or None."""
-    lats: list[float] = []
-    lons: list[float] = []
-    for vol in volumes:
-        inner = vol.get("volume", vol)
-        polygon = inner.get("outline_polygon", {})
-        for vertex in polygon.get("vertices", polygon.get("coordinates", [])):
-            if isinstance(vertex, dict):
-                lat = vertex.get("lat", vertex.get("latitude"))
-                lng = vertex.get("lng", vertex.get("longitude", vertex.get("lon")))
-                if lat is not None and lng is not None:
-                    lats.append(float(lat))
-                    lons.append(float(lng))
-            elif isinstance(vertex, (list, tuple)) and len(vertex) >= 2:
-                lons.append(float(vertex[0]))
-                lats.append(float(vertex[1]))
-    if not lats or not lons:
-        return None
-    return [min(lons), min(lats), max(lons), max(lats)]
+def _point_in_ring(lon: float, lat: float, ring: list[list[float]]) -> bool:
+    """Ray-casting point-in-polygon test for a single ``[lon, lat]`` ring."""
+    inside = False
+    n = len(ring)
+    if n < 3:
+        return False
+    j = n - 1
+    for i in range(n):
+        xi, yi = ring[i][0], ring[i][1]
+        xj, yj = ring[j][0], ring[j][1]
+        if ((yi > lat) != (yj > lat)) and (lon < (xj - xi) * (lat - yi) / ((yj - yi) or 1e-12) + xi):
+            inside = not inside
+        j = i
+    return inside
 
 
-@router.post("/geo_awareness/map/queries", dependencies=[ReadDep])
+def _bounds_contains_point(bounds: str, lon: float, lat: float) -> bool:
+    """Return True if the comma-separated ``minx,miny,maxx,maxy`` bounds cover the point."""
+    try:
+        minx, miny, maxx, maxy = (float(x) for x in bounds.split(","))
+    except (ValueError, AttributeError):
+        return False
+    return minx <= lon <= maxx and miny <= lat <= maxy
+
+
+def _geozone_covers_point(fence: GeoFence, lon: float, lat: float) -> bool:
+    """Point membership: try the stored geometry ring, fall back to the bbox."""
+    from flight_blender.tasks.geo_fence import feature_to_coordinates
+
+    if fence.geozone:
+        try:
+            ring = feature_to_coordinates(json.loads(fence.geozone))
+            if ring:
+                return _point_in_ring(lon, lat, ring)
+        except (TypeError, ValueError):
+            pass
+    return _bounds_contains_point(fence.bounds or "", lon, lat)
+
+
+@router.post("/geo_awareness/map/queries", response_model=GeoZoneChecksResponse, dependencies=[GeoAwarenessTestDep])
 async def geo_awareness_zone_query(payload: GeoZoneQueryRequest, db: AsyncSession = Depends(get_db)):
-    """Return GeoZone features intersecting the queried volumes."""
-    stmt = select(GeoFence).where(GeoFence.status == 1)
-    if payload.after is not None and payload.before is not None:
-        stmt = stmt.where(GeoFence.start_datetime <= payload.before).where(GeoFence.end_datetime >= payload.after)
-    result = await db.execute(stmt.limit(500))
+    """ED-269 spatial check over test-dataset geozones.
+
+    Accepts the InterUSS ``{"checks": [{"filter_sets": [...]}]}`` body and returns
+    ``{"applicableGeozone": [{"geozone": "Present" | "Absent"}]}``.
+    """
+    result = await db.execute(select(GeoFence).where(GeoFence.is_test_dataset.is_(True)))
     fences = result.scalars().all()
 
-    view_box = _extract_view_box(payload.volumes)
-    if view_box is not None:
-        view_minx, view_miny, view_maxx, view_maxy = view_box
-        matching = []
-        for f in fences:
-            try:
-                b = json.loads(f.bounds)
-                if b.get("minx") <= view_maxx and b.get("maxx") >= view_minx and b.get("miny") <= view_maxy and b.get("maxy") >= view_miny:
-                    matching.append(f)
-            except (TypeError, ValueError, AttributeError):
-                pass
-        fences = matching
+    geo_zones_of_interest = False
+    for check in payload.checks:
+        for filter_set in check.get("filter_sets", []):
+            if "position" in filter_set:
+                pos = filter_set["position"]
+                lon, lat = None, None
+                if isinstance(pos, dict):
+                    lon = pos.get("lng", pos.get("longitude", pos.get("lon")))
+                    lat = pos.get("lat", pos.get("latitude"))
+                elif isinstance(pos, (list, tuple)) and len(pos) >= 2:
+                    lon, lat = pos[0], pos[1]
+                if lon is not None and lat is not None:
+                    if any(_geozone_covers_point(f, float(lon), float(lat)) for f in fences):
+                        geo_zones_of_interest = True
+            if "after" in filter_set:
+                after_dt = _parse_fence_dt(filter_set, "after", datetime.now(timezone.utc))
+                if any(f.end_datetime and f.end_datetime >= after_dt for f in fences):
+                    geo_zones_of_interest = True
+            if "before" in filter_set:
+                before_dt = _parse_fence_dt(filter_set, "before", datetime.now(timezone.utc))
+                if any(f.start_datetime and f.start_datetime <= before_dt for f in fences):
+                    geo_zones_of_interest = True
 
-    return {"zones": [{"id": str(f.id), "name": f.name} for f in fences]}
-
-
-# ── Geospatial data sources (USS qualifier harness) ────────────────────────────
-
-
-@router.get("/geo_awareness/geospatial_data_sources", dependencies=[ReadDep])
-async def list_geospatial_data_sources():
-    return {"sources": []}
-
-
-@router.post("/geo_awareness/geospatial_data_sources", status_code=status.HTTP_201_CREATED, dependencies=[WriteDep])
-async def create_geospatial_data_source(payload: dict):
-    url = payload.get("url")
-    if not url:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="url is required")
-    download_geozone_source.delay(url)
-    return {"message": "GeoZone source download queued", "url": url}
+    geozone = "Present" if geo_zones_of_interest else "Absent"
+    return GeoZoneChecksResponse(applicableGeozone=[GeoZoneCheckResult(geozone=geozone)], message="Test")
 
 
-@router.get("/geo_awareness/geospatial_data_sources/{source_id}", dependencies=[ReadDep])
-async def get_geospatial_data_source(source_id: uuid.UUID = Path(...)):
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data source not found")
+# ── Geospatial data sources (InterUSS qualifier harness) ───────────────────────
 
 
-@router.delete("/geo_awareness/geospatial_data_sources/{source_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[WriteDep])
-async def delete_geospatial_data_source(source_id: uuid.UUID = Path(...)):
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data source not found")
+@router.put("/geo_awareness/geospatial_data_sources/{source_id}", response_model=GeoAwarenessTestStatus, dependencies=[GeoAwarenessTestDep])
+async def put_geospatial_data_source(payload: GeoZoneSourceRequest, source_id: str = Path(...)):
+    """Register/replace a geozone source: enqueue the download and record status."""
+    geo_zone_url = payload.https_source.url
+    download_geozone_source.delay(geo_zone_url=geo_zone_url, geozone_source_id=source_id)
+    status_record = {"result": "Activating", "message": ""}
+    set_geozone_source_status(source_id, status_record)
+    return GeoAwarenessTestStatus(**status_record)
+
+
+@router.get("/geo_awareness/geospatial_data_sources/{source_id}", response_model=GeoAwarenessTestStatus, dependencies=[GeoAwarenessTestDep])
+async def get_geospatial_data_source(source_id: str = Path(...)):
+    record = get_geozone_source_status(source_id)
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data source not found")
+    return GeoAwarenessTestStatus(result=record.get("result", ""), message=record.get("message", ""))
+
+
+@router.delete("/geo_awareness/geospatial_data_sources/{source_id}", response_model=GeoAwarenessTestStatus, dependencies=[GeoAwarenessTestDep])
+async def delete_geospatial_data_source(source_id: str = Path(...), db: AsyncSession = Depends(get_db)):
+    if get_geozone_source_status(source_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data source not found")
+    # Schedule deletion of the test datasets associated with this source.
+    result = await db.execute(select(GeoFence).where(GeoFence.is_test_dataset.is_(True)))
+    for fence in result.scalars().all():
+        await db.delete(fence)
+    deletion_status = {"result": "Deactivating", "message": "Test data has been scheduled to be deleted"}
+    set_geozone_source_status(source_id, deletion_status)
+    delete_geozone_source_status(source_id)
+    return GeoAwarenessTestStatus(**deletion_status)

--- a/src/flight_blender/routers/rid.py
+++ b/src/flight_blender/routers/rid.py
@@ -11,14 +11,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from flight_blender.auth import ReadDep, WriteDep
 from flight_blender.database import get_db
-from flight_blender.models.rid import ISASubscription
 from flight_blender.models.notification import OperatorRIDNotification
+from flight_blender.models.rid import ISASubscription, RIDFlightDetail
 from flight_blender.schemas.rid import (
     CreateDSSSubscriptionRequest,
     CreateTestRequest,
     ISASubscriptionResponse,
     RIDCapabilitiesResponse,
     RIDDisplayDataResponse,
+    RIDFlightDetailCreate,
+    RIDFlightDetailResponse,
     RIDFlightDetailsResponse,
     RIDTestResponse,
     RIDUserNotificationsResponse,
@@ -78,6 +80,36 @@ async def get_rid_display_data(
 async def get_rid_flight_detail(flight_id: str = Path(...)):
     """Return detailed RID data for a specific flight."""
     return RIDFlightDetailsResponse(id=flight_id)
+
+
+# ── RID Flight Details (persisted operator metadata) ───────────────────────────
+
+
+@router.post("/flight_details", response_model=RIDFlightDetailResponse, status_code=status.HTTP_201_CREATED, dependencies=[WriteDep])
+async def create_rid_flight_detail(payload: RIDFlightDetailCreate, db: AsyncSession = Depends(get_db)):
+    """Persist RID operator/flight details (Django ``RIDFlightDetail``).
+
+    Dict-valued ASTM fields (operator_location, auth_data, uas_id,
+    eu_classification) are stored as JSON text, matching Django's storage; they
+    are served back over the peer-USS ``GET /uss/flights/<id>/details`` endpoint.
+    """
+    import json
+
+    def _dump(value):
+        return json.dumps(value) if value is not None else None
+
+    detail = RIDFlightDetail(
+        operation_description=payload.operation_description,
+        operator_id=payload.operator_id,
+        operator_location=_dump(payload.operator_location),
+        auth_data=_dump(payload.auth_data),
+        uas_id=_dump(payload.uas_id),
+        eu_classification=_dump(payload.eu_classification),
+    )
+    db.add(detail)
+    await db.flush()
+    await db.refresh(detail)
+    return detail
 
 
 # ── USS Qualifier test harness ─────────────────────────────────────────────────

--- a/src/flight_blender/routers/scd.py
+++ b/src/flight_blender/routers/scd.py
@@ -5,6 +5,7 @@ FastAPI router for SCD (Strategic Conflict Detection) operations.
 import json
 import uuid
 from datetime import datetime, timezone
+from enum import StrEnum
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 from loguru import logger
@@ -28,16 +29,32 @@ from flight_blender.services.deconfliction import DeconflictionEngine, Deconflic
 router = APIRouter()
 
 # Active operational states whose declarations must be deconflicted against.
-_ACTIVE_STATES = [1, 2, 3, 4]  # Accepted, Activated, NonConforming, Contingent
+_ACTIVE_STATES = [
+    OperationState.ACCEPTED,
+    OperationState.ACTIVATED,
+    OperationState.NONCONFORMING,
+    OperationState.CONTINGENT,
+]
 
-# ASTM planning result strings (matching the Django SCD endpoint).
-PLANNING_RESULT_PLANNED = "Planned"
-PLANNING_RESULT_CONFLICT = "ConflictWithFlight"
-PLANNING_RESULT_NOT_PLANNED = "NotPlanned"
-PLANNING_RESULT_FAILED = "Failed"
+
+class PlanningResult(StrEnum):
+    """ASTM F3548-21 flight-planning result statuses (Django SCD parity)."""
+
+    PLANNED = "Planned"
+    CONFLICT = "ConflictWithFlight"
+    NOT_PLANNED = "NotPlanned"
+    FAILED = "Failed"
+
+
+class UsageState(StrEnum):
+    """ASTM operational-intent usage states that trigger strategic deconfliction."""
+
+    PLANNED = "Planned"
+    IN_USE = "InUse"
+
 
 # usage_state values that trigger strategic deconfliction (Django Planned/InUse).
-_PLANNING_USAGE_STATES = {"Planned", "InUse"}
+_PLANNING_USAGE_STATES = {UsageState.PLANNED, UsageState.IN_USE}
 
 
 def _altitude_value(alt: dict | None) -> float | None:

--- a/src/flight_blender/routers/scd.py
+++ b/src/flight_blender/routers/scd.py
@@ -2,12 +2,17 @@
 FastAPI router for SCD (Strategic Conflict Detection) operations.
 """
 
+import json
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status
+from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from flight_blender.auth import ReadDep, WriteDep
+from flight_blender.common.plugin_loader import load_plugin
 from flight_blender.config import get_settings
 from flight_blender.database import get_db
 from flight_blender.schemas.scd import (
@@ -18,8 +23,172 @@ from flight_blender.schemas.scd import (
     SCDCapabilitiesResponse,
     SCDStatusResponse,
 )
+from flight_blender.services.deconfliction import DeconflictionEngine, DeconflictionRequest
 
 router = APIRouter()
+
+# Active operational states whose declarations must be deconflicted against.
+_ACTIVE_STATES = [1, 2, 3, 4]  # Accepted, Activated, NonConforming, Contingent
+
+# ASTM planning result strings (matching the Django SCD endpoint).
+PLANNING_RESULT_PLANNED = "Planned"
+PLANNING_RESULT_CONFLICT = "ConflictWithFlight"
+PLANNING_RESULT_NOT_PLANNED = "NotPlanned"
+PLANNING_RESULT_FAILED = "Failed"
+
+# usage_state values that trigger strategic deconfliction (Django Planned/InUse).
+_PLANNING_USAGE_STATES = {"Planned", "InUse"}
+
+
+def _altitude_value(alt: dict | None) -> float | None:
+    if not isinstance(alt, dict):
+        return None
+    for key in ("meters", "value", "altitude"):
+        if key in alt:
+            try:
+                return float(alt[key])
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _parse_dt(value: object) -> datetime | None:
+    if isinstance(value, dict):
+        value = value.get("value")
+    if isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value)
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    return None
+
+
+def _candidate_volume_from_astm_volume(v4d: dict) -> dict | None:
+    """Extract a 4D volume (coordinates + altitude + time) from a single ASTM
+    Volume4D dict (``{volume: {outline_polygon, altitude_lower/upper}, time_start, time_end}``)."""
+    volume = v4d.get("volume", v4d)
+    outline = volume.get("outline_polygon", {})
+    vertices = outline.get("vertices", [])
+    coords: list[list[float]] = []
+    if vertices:
+        coords = [[float(v.get("lng", 0)), float(v.get("lat", 0))] for v in vertices]
+    else:
+        ring = outline.get("coordinates", [[]])
+        ring = ring[0] if ring else []
+        coords = [[float(pt[0]), float(pt[1])] for pt in ring]
+    if not coords:
+        return None
+    min_alt = _altitude_value(volume.get("altitude_lower"))
+    max_alt = _altitude_value(volume.get("altitude_upper"))
+    return {
+        "coordinates": coords,
+        "min_alt": min_alt if min_alt is not None else float("-inf"),
+        "max_alt": max_alt if max_alt is not None else float("inf"),
+        "start": _parse_dt(v4d.get("time_start")),
+        "end": _parse_dt(v4d.get("time_end")),
+    }
+
+
+def _candidate_volumes_from_intended_flight(intended_flight: dict) -> list[dict]:
+    """Extract candidate 4D volumes from an ASTM ``intended_flight`` payload."""
+    op_intent = intended_flight.get("operational_intent", {}) or {}
+    volumes = (op_intent.get("volumes") or []) + (op_intent.get("off_nominal_volumes") or [])
+    candidates = []
+    for v4d in volumes:
+        cand = _candidate_volume_from_astm_volume(v4d)
+        if cand is not None:
+            candidates.append(cand)
+    return candidates
+
+
+def _volume_from_geojson(geo_json: dict | None, start: datetime, end: datetime) -> dict | None:
+    if not geo_json:
+        return None
+    features = geo_json.get("features") or []
+    if not features:
+        return None
+    feature = features[0]
+    coords_raw = feature.get("geometry", {}).get("coordinates", [[]])
+    ring = coords_raw[0] if coords_raw else []
+    if not ring:
+        return None
+    props = feature.get("properties", {}) or {}
+    min_alt = _altitude_value(props.get("min_altitude"))
+    max_alt = _altitude_value(props.get("max_altitude"))
+    return {
+        "coordinates": [[float(pt[0]), float(pt[1])] for pt in ring],
+        "min_alt": min_alt if min_alt is not None else float("-inf"),
+        "max_alt": max_alt if max_alt is not None else float("inf"),
+        "start": start,
+        "end": end,
+    }
+
+
+async def _existing_volumes(db: AsyncSession) -> list[dict]:
+    """Build 4D volumes for all active declarations to deconflict against."""
+    from flight_blender.models.flight_declaration import FlightDeclaration
+
+    decl_result = await db.execute(select(FlightDeclaration).where(FlightDeclaration.state.in_(_ACTIVE_STATES)))
+    declarations = decl_result.scalars().all()
+    volumes: list[dict] = []
+    for d in declarations:
+        d_start = d.start_datetime if d.start_datetime.tzinfo else d.start_datetime.replace(tzinfo=timezone.utc)
+        d_end = d.end_datetime if d.end_datetime.tzinfo else d.end_datetime.replace(tzinfo=timezone.utc)
+        d_geo = json.loads(d.flight_declaration_raw_geojson) if d.flight_declaration_raw_geojson else None
+        d_vol = _volume_from_geojson(d_geo, d_start, d_end)
+        if d_vol is not None:
+            volumes.append(d_vol)
+    return volumes
+
+
+def _resolve_usage_state(payload: FlightPlanUpsertRequest, intended: dict) -> str:
+    """Return the effective usage_state, preferring a nested basic_information one."""
+    basic = intended.get("basic_information", {}) or {}
+    return basic.get("usage_state") or payload.usage_state
+
+
+def _conflicts_with_existing(candidates: list[dict], existing: list[dict], ussp_network_enabled: int) -> bool:
+    """Return True if any candidate volume conflicts with an existing one."""
+    engine_cls = load_plugin(get_settings().plugin_deconfliction_engine, expected_protocol=DeconflictionEngine)
+    engine = engine_cls()
+    for candidate in candidates:
+        req = DeconflictionRequest(
+            candidate_volume=candidate,
+            prefetched_volumes=existing,
+            ussp_network_enabled=ussp_network_enabled,
+        )
+        if not engine.check_deconfliction(req).is_approved:
+            return True
+    return False
+
+
+async def _strategic_planning_result(payload: FlightPlanUpsertRequest, db: AsyncSession) -> str:
+    """Compute an ASTM planning result by running strategic deconfliction
+    against active declarations in the DB.
+
+    Mirrors Django ``upsert_close_flight_plan``: only Planned/InUse usage states
+    with at least one candidate volume run deconfliction. Fails closed: any
+    error yields ``Failed`` rather than an optimistic ``Planned``.
+    """
+    settings = get_settings()
+    try:
+        intended = payload.intended_flight or {}
+        if _resolve_usage_state(payload, intended) not in _PLANNING_USAGE_STATES:
+            return PLANNING_RESULT_NOT_PLANNED
+
+        candidates = _candidate_volumes_from_intended_flight(intended)
+        if not candidates:
+            # Nothing concrete to plan -> Django returns NotPlanned for an empty op-intent.
+            return PLANNING_RESULT_NOT_PLANNED
+
+        existing = await _existing_volumes(db)
+        if _conflicts_with_existing(candidates, existing, int(settings.ussp_network_enabled)):
+            return PLANNING_RESULT_CONFLICT
+        return PLANNING_RESULT_PLANNED
+    except Exception as exc:
+        logger.error("SCD strategic deconfliction error; failing closed: {}", exc)
+        return PLANNING_RESULT_FAILED
 
 
 # ── SCD v1 ─────────────────────────────────────────────────────────────────────
@@ -46,8 +215,13 @@ async def upsert_flight_plan(
 ):
     settings = get_settings()
     if settings.ussp_network_enabled:
+        # USSP network requires submitting the op-intent to the DSS for
+        # network-wide strategic deconfliction (follow-up wiring).
         raise HTTPException(status_code=503, detail="DSS integration not yet implemented in FastAPI port")
-    return FlightPlanResponse(flight_plan_id=flight_plan_id, planning_result="NotPlanned", notes="USSP network not enabled — DSS integration required for flight planning")
+    planning_result = await _strategic_planning_result(payload, db)
+    return FlightPlanResponse(
+        flight_plan_id=flight_plan_id, planning_result=planning_result, notes="Local strategic deconfliction (USSP network disabled)"
+    )
 
 
 @router.delete("/flight_planning/flight_plans/{flight_plan_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[WriteDep])
@@ -80,7 +254,10 @@ async def upsert_uspace_flight_plan(
     settings = get_settings()
     if settings.ussp_network_enabled:
         raise HTTPException(status_code=503, detail="DSS integration not yet implemented in FastAPI port")
-    return FlightPlanResponse(flight_plan_id=flight_plan_id, planning_result="NotPlanned", notes="USSP network not enabled — DSS integration required for flight planning")
+    planning_result = await _strategic_planning_result(payload, db)
+    return FlightPlanResponse(
+        flight_plan_id=flight_plan_id, planning_result=planning_result, notes="Local strategic deconfliction (USSP network disabled)"
+    )
 
 
 @router.delete("/flight_planning/u_space/flight_plans/{flight_plan_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[WriteDep])

--- a/src/flight_blender/routers/scd.py
+++ b/src/flight_blender/routers/scd.py
@@ -13,6 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from flight_blender.auth import ReadDep, WriteDep
+from flight_blender.common.enums import OperationState
 from flight_blender.common.plugin_loader import load_plugin
 from flight_blender.config import get_settings
 from flight_blender.database import get_db
@@ -192,20 +193,20 @@ async def _strategic_planning_result(payload: FlightPlanUpsertRequest, db: Async
     try:
         intended = payload.intended_flight or {}
         if _resolve_usage_state(payload, intended) not in _PLANNING_USAGE_STATES:
-            return PLANNING_RESULT_NOT_PLANNED
+            return PlanningResult.NOT_PLANNED
 
         candidates = _candidate_volumes_from_intended_flight(intended)
         if not candidates:
             # Nothing concrete to plan -> Django returns NotPlanned for an empty op-intent.
-            return PLANNING_RESULT_NOT_PLANNED
+            return PlanningResult.NOT_PLANNED
 
         existing = await _existing_volumes(db)
         if _conflicts_with_existing(candidates, existing, int(settings.ussp_network_enabled)):
-            return PLANNING_RESULT_CONFLICT
-        return PLANNING_RESULT_PLANNED
+            return PlanningResult.CONFLICT
+        return PlanningResult.PLANNED
     except Exception as exc:
         logger.error("SCD strategic deconfliction error; failing closed: {}", exc)
-        return PLANNING_RESULT_FAILED
+        return PlanningResult.FAILED
 
 
 # ── SCD v1 ─────────────────────────────────────────────────────────────────────

--- a/src/flight_blender/routers/scd.py
+++ b/src/flight_blender/routers/scd.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from flight_blender.auth import ReadDep, WriteDep
-from flight_blender.common.enums import OperationState
+from flight_blender.common.enums import OperationState, VALID_OPERATIONAL_INTENT_STATES
 from flight_blender.common.plugin_loader import load_plugin
 from flight_blender.config import get_settings
 from flight_blender.database import get_db
@@ -30,12 +30,7 @@ from flight_blender.services.deconfliction import DeconflictionEngine, Deconflic
 router = APIRouter()
 
 # Active operational states whose declarations must be deconflicted against.
-_ACTIVE_STATES = [
-    OperationState.ACCEPTED,
-    OperationState.ACTIVATED,
-    OperationState.NONCONFORMING,
-    OperationState.CONTINGENT,
-]
+_ACTIVE_STATES = list(VALID_OPERATIONAL_INTENT_STATES)
 
 
 class PlanningResult(StrEnum):
@@ -71,15 +66,12 @@ def _altitude_value(alt: dict | None) -> float | None:
 
 
 def _parse_dt(value: object) -> datetime | None:
+    """Parse a datetime from an ISO string, optionally unwrapping ``{"value": ...}`` dicts."""
     if isinstance(value, dict):
         value = value.get("value")
-    if isinstance(value, str):
-        try:
-            dt = datetime.fromisoformat(value)
-            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
-        except ValueError:
-            return None
-    return None
+    from flight_blender.common.datetime_utils import parse_iso_utc
+
+    return parse_iso_utc(value)
 
 
 def _candidate_volume_from_astm_volume(v4d: dict) -> dict | None:
@@ -225,21 +217,34 @@ async def scd_capabilities():
 # ── Flight planning ─────────────────────────────────────────────────────────────
 
 
+async def _upsert_flight_plan_impl(
+    payload: FlightPlanUpsertRequest,
+    flight_plan_id: uuid.UUID,
+    db: AsyncSession,
+) -> FlightPlanResponse:
+    settings = get_settings()
+    if settings.ussp_network_enabled:
+        raise HTTPException(status_code=503, detail="DSS integration not yet implemented in FastAPI port")
+    planning_result = await _strategic_planning_result(payload, db)
+    return FlightPlanResponse(
+        flight_plan_id=flight_plan_id, planning_result=planning_result, notes="Local strategic deconfliction (USSP network disabled)"
+    )
+
+
+def _clear_area_impl() -> ClearAreaResponse:
+    settings = get_settings()
+    if settings.ussp_network_enabled:
+        raise HTTPException(status_code=503, detail="DSS integration not yet implemented in FastAPI port")
+    return ClearAreaResponse(outcome={"success": False, "message": "USSP network not enabled"})
+
+
 @router.put("/flight_planning/flight_plans/{flight_plan_id}", response_model=FlightPlanResponse, dependencies=[WriteDep])
 async def upsert_flight_plan(
     payload: FlightPlanUpsertRequest,
     flight_plan_id: uuid.UUID = Path(...),
     db: AsyncSession = Depends(get_db),
 ):
-    settings = get_settings()
-    if settings.ussp_network_enabled:
-        # USSP network requires submitting the op-intent to the DSS for
-        # network-wide strategic deconfliction (follow-up wiring).
-        raise HTTPException(status_code=503, detail="DSS integration not yet implemented in FastAPI port")
-    planning_result = await _strategic_planning_result(payload, db)
-    return FlightPlanResponse(
-        flight_plan_id=flight_plan_id, planning_result=planning_result, notes="Local strategic deconfliction (USSP network disabled)"
-    )
+    return await _upsert_flight_plan_impl(payload, flight_plan_id, db)
 
 
 @router.delete("/flight_planning/flight_plans/{flight_plan_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[WriteDep])
@@ -249,10 +254,7 @@ async def delete_flight_plan(flight_plan_id: uuid.UUID = Path(...), db: AsyncSes
 
 @router.post("/flight_planning/clear_area_requests", response_model=ClearAreaResponse, dependencies=[WriteDep])
 async def clear_area(payload: ClearAreaRequest):
-    settings = get_settings()
-    if settings.ussp_network_enabled:
-        raise HTTPException(status_code=503, detail="DSS integration not yet implemented in FastAPI port")
-    return ClearAreaResponse(outcome={"success": False, "message": "USSP network not enabled"})
+    return _clear_area_impl()
 
 
 @router.get("/flight_planning/status", response_model=SCDStatusResponse, dependencies=[ReadDep])
@@ -269,13 +271,7 @@ async def upsert_uspace_flight_plan(
     flight_plan_id: uuid.UUID = Path(...),
     db: AsyncSession = Depends(get_db),
 ):
-    settings = get_settings()
-    if settings.ussp_network_enabled:
-        raise HTTPException(status_code=503, detail="DSS integration not yet implemented in FastAPI port")
-    planning_result = await _strategic_planning_result(payload, db)
-    return FlightPlanResponse(
-        flight_plan_id=flight_plan_id, planning_result=planning_result, notes="Local strategic deconfliction (USSP network disabled)"
-    )
+    return await _upsert_flight_plan_impl(payload, flight_plan_id, db)
 
 
 @router.delete("/flight_planning/u_space/flight_plans/{flight_plan_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[WriteDep])
@@ -285,10 +281,7 @@ async def delete_uspace_flight_plan(flight_plan_id: uuid.UUID = Path(...)):
 
 @router.post("/flight_planning/u_space/clear_area_requests", response_model=ClearAreaResponse, dependencies=[WriteDep])
 async def clear_uspace_area(payload: ClearAreaRequest):
-    settings = get_settings()
-    if settings.ussp_network_enabled:
-        raise HTTPException(status_code=503, detail="DSS integration not yet implemented in FastAPI port")
-    return ClearAreaResponse(outcome={"success": False, "message": "USSP network not enabled"})
+    return _clear_area_impl()
 
 
 @router.get("/flight_planning/u_space/status", response_model=SCDStatusResponse, dependencies=[ReadDep])

--- a/src/flight_blender/routers/surveillance.py
+++ b/src/flight_blender/routers/surveillance.py
@@ -33,14 +33,7 @@ from flight_blender.schemas.surveillance import (
 from flight_blender.tasks.surveillance import send_and_generate_track_to_consumer, send_heartbeat_to_consumer
 
 
-def _parse_iso_dt(value: str | None) -> datetime | None:
-    """Parse an ISO-8601 date string, returning None on failure."""
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value)
-    except ValueError:
-        return None
+from flight_blender.common.datetime_utils import parse_iso_utc as _parse_iso_dt
 
 
 def _apply_time_window(query: Select, model: Any, start_dt: datetime | None, end_dt: datetime | None) -> Select:

--- a/src/flight_blender/routers/surveillance.py
+++ b/src/flight_blender/routers/surveillance.py
@@ -11,6 +11,7 @@ from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from flight_blender.auth import ReadDep, WriteDep
+from flight_blender.common.redis_stream_operations import read_all_observations
 from flight_blender.database import get_db
 from flight_blender.models.surveillance import (
     SurveillanceHeartbeatEvent,
@@ -98,6 +99,18 @@ async def start_stop_heartbeat(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
         await db.delete(existing)
         return {"message": "Heartbeat stopped", "session_id": str(session_id)}
+
+
+@router.get("/get_air_traffic", dependencies=[ReadDep])
+async def get_air_traffic(session_id: str | None = None):
+    """Return the latest air-traffic observations for display.
+
+    Mirrors the Django ``get_air_traffic`` GET view: it reads the most-recent
+    observations from the Redis stream (optionally filtered by ``session_id``)
+    and returns them under an ``observations`` key. Guarded by the READ scope.
+    """
+    observations = read_all_observations(session_id=session_id, count=500)
+    return {"observations": observations}
 
 
 @router.get("/list_surveillance_sensors", response_model=list[SurveillanceSensorResponse], dependencies=[ReadDep])

--- a/src/flight_blender/routers/uss.py
+++ b/src/flight_blender/routers/uss.py
@@ -2,12 +2,15 @@
 FastAPI router for USS interoperability operations.
 """
 
+import json
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Path, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from flight_blender.auth import ReadDep, WriteDep
+from flight_blender.auth import ReadDep, RIDDisplayProviderDep, WriteDep
+from flight_blender.common.redis_stream_operations import read_all_observations
 from flight_blender.database import get_db
 from flight_blender.schemas.uss import (
     ConstraintDetailsResponse,
@@ -90,19 +93,99 @@ async def notify_constraint_change(payload: dict):
     return {"message": "Constraint change acknowledged"}
 
 
-# ── Flights ────────────────────────────────────────────────────────────────────
+# ── Peer-USS Remote-ID exchange (ASTM F3411) ────────────────────────────────────
+#
+# These USS-to-USS RID endpoints are presented by OTHER USSs (RID display
+# providers) and therefore require the RID-specific ``rid.display_provider``
+# scope rather than the generic blender read scope. Django served them at
+# ``/uss/flights`` and ``/uss/flights/<flight_id>/details``.
 
 
-@router.get("/flights", response_model=USSFlightResponse, dependencies=[ReadDep])
-async def get_all_flights(db: AsyncSession = Depends(get_db)):
-    from sqlalchemy import select
-    from flight_blender.models.flight_declaration import FlightDeclaration
+@router.get("/flights", response_model=USSFlightResponse, dependencies=[RIDDisplayProviderDep])
+async def get_uss_flights(
+    view: str | None = Query(None, description="Bounding box: 'lat_lo,lng_lo,lat_hi,lng_hi'"),
+):
+    """Return RID flights visible within *view* (ASTM F3411 ``getFlights``).
 
-    result = await db.execute(select(FlightDeclaration).where(FlightDeclaration.state.in_([1, 2])).limit(100))
-    flights = [{"id": str(f.id), "state": f.state} for f in result.scalars().all()]
-    return USSFlightResponse(flights=flights)
+    Mirrors Django ``get_uss_flights``: when a *view* is supplied it is
+    validated, then the most recent telemetry observations are read from the
+    live stream. Returns the ASTM ``GetFlightsResponse`` shape
+    ``{"timestamp": ..., "flights": [...]}``.
+    """
+    from datetime import datetime, timezone
+
+    if view is not None:
+        try:
+            view_port = [float(v) for v in view.split(",")]
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A view bbox is necessary with four values: minx, miny, maxx and maxy",
+            ) from exc
+        if len(view_port) != 4:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="The requested view rectangle is not valid format: lat1,lng1,lat2,lng2",
+            )
+
+    try:
+        observations = read_all_observations() or []
+    except Exception as exc:  # pragma: no cover - stream unavailable -> no flights
+        logger.warning("RID flight stream unavailable: {}", exc)
+        observations = []
+
+    flights: list[dict] = []
+    for obs in observations:
+        metadata = obs.get("metadata") if isinstance(obs, dict) else None
+        if isinstance(metadata, dict) and "telemetry" in metadata:
+            flights.append(
+                {
+                    "id": metadata.get("injection_id") or obs.get("icao_address", ""),
+                    "aircraft_type": metadata.get("aircraft_type"),
+                    "current_state": metadata.get("telemetry"),
+                    "simulated": True,
+                    "recent_positions": [],
+                }
+            )
+
+    return USSFlightResponse(timestamp={"value": datetime.now(timezone.utc).isoformat(), "format": "RFC3339"}, flights=flights)
 
 
-@router.get("/flights/{flight_id}/details", response_model=USSFlightDetailResponse, dependencies=[ReadDep])
-async def get_flight_details(flight_id: str = Path(...), db: AsyncSession = Depends(get_db)):
-    return USSFlightDetailResponse(id=flight_id, details={})
+@router.get("/flights/{flight_id}/details", response_model=USSFlightDetailResponse, dependencies=[RIDDisplayProviderDep])
+async def get_uss_flight_details(flight_id: str = Path(...), db: AsyncSession = Depends(get_db)):
+    """Return operator details for a RID flight (ASTM F3411 ``getFlightDetails``).
+
+    Mirrors Django ``get_uss_flight_details``: looks up the persisted
+    ``RIDFlightDetail`` by id and returns the ASTM ``{"details": {...}}`` shape,
+    or 404 when the flight is unknown.
+    """
+    from flight_blender.models.rid import RIDFlightDetail
+
+    try:
+        detail_pk = uuid.UUID(flight_id)
+    except (ValueError, AttributeError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The requested flight could not be found") from None
+
+    obj = await db.get(RIDFlightDetail, detail_pk)
+    if obj is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The requested flight could not be found")
+
+    def _maybe_json(raw):
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except (ValueError, TypeError):
+            return raw
+
+    details = {
+        "id": str(obj.id),
+        "operator_id": obj.operator_id,
+        "operator_location": _maybe_json(obj.operator_location),
+        "operation_description": obj.operation_description,
+        "auth_data": _maybe_json(obj.auth_data),
+        "uas_id": _maybe_json(obj.uas_id),
+        "eu_classification": _maybe_json(obj.eu_classification),
+    }
+    details = {k: v for k, v in details.items() if v is not None}
+    return USSFlightDetailResponse(details=details)

--- a/src/flight_blender/routers/weather.py
+++ b/src/flight_blender/routers/weather.py
@@ -1,10 +1,18 @@
 """
 FastAPI router for weather monitoring operations.
+
+Mirrors the Django ``WeatherAPIView``: requires the write scope, does
+presence-only validation (missing lon/lat -> 400 ``{"error": ...}``), forwards
+``time``/``timezone`` to the service, and returns the full upstream object
+serialized to the Django ``WeatherSerializer`` shape.
 """
 
-from fastapi import APIRouter, HTTPException, Query, status
+import httpx
+from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse
+from loguru import logger
 
-from flight_blender.auth import ReadDep
+from flight_blender.auth import WriteDep
 from flight_blender.config import get_settings
 from flight_blender.schemas.weather import WeatherResponse
 from flight_blender.services.weather_service import WeatherService
@@ -13,15 +21,24 @@ router = APIRouter()
 settings = get_settings()
 
 
-@router.get("/weather/", response_model=WeatherResponse, dependencies=[ReadDep])
+@router.get("/weather/", response_model=WeatherResponse, dependencies=[WriteDep])
 async def get_weather(
-    latitude: float = Query(..., ge=-90.0, le=90.0),
-    longitude: float = Query(..., ge=-180.0, le=180.0),
+    latitude: float | None = Query(default=None),
+    longitude: float | None = Query(default=None),
+    time: float | None = Query(default=None),
     timezone: str = Query(default="UTC"),
 ):
+    # Presence-only validation, matching the Django contract (400 + {"error": ...}).
+    if longitude is None:
+        return JSONResponse(status_code=400, content={"error": "Longitude parameter is required"})
+    if latitude is None:
+        return JSONResponse(status_code=400, content={"error": "Latitude parameter is required"})
+
     service = WeatherService(base_url=settings.weather_api_base_url)
     try:
-        data = await service.get_weather(longitude=longitude, latitude=latitude, timezone=timezone)
-    except Exception as exc:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"Weather service error: {exc}") from exc
-    return WeatherResponse(latitude=latitude, longitude=longitude, current_weather=data.get("current_weather"), hourly=data.get("hourly"))
+        data = await service.get_weather(longitude=longitude, latitude=latitude, timezone=timezone, time=time)
+    except (httpx.HTTPError, ValueError) as exc:
+        # Log the detail but do not leak the upstream response body to the client.
+        logger.error(f"Upstream weather service error: {exc}")
+        return JSONResponse(status_code=502, content={"error": "Upstream weather service error"})
+    return data

--- a/src/flight_blender/schemas/deconfliction.py
+++ b/src/flight_blender/schemas/deconfliction.py
@@ -1,0 +1,51 @@
+"""
+Pydantic schemas for peer-USS / DSS operational-intent exchange.
+
+These are the minimal, parsing-oriented models used by the peer-USS client
+(``services/peer_uss_client.py``) to represent an op-intent *reference*
+(uss_base_url + id, as returned by a DSS area query) and the *details*
+(volumes) fetched from a peer USS — the inputs to strategic deconfliction.
+They intentionally mirror the relevant subset of the Django
+``scd_operations/scd_data_definitions.py`` dataclasses.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class LatLng(BaseModel):
+    """A WGS84 latitude/longitude vertex."""
+
+    lat: float
+    lng: float
+
+
+class Volume4D(BaseModel):
+    """A parsed 4D volume from a peer op-intent (outline + altitude band + time)."""
+
+    outline_polygon: list[LatLng] = []
+    altitude_lower: float | None = None
+    altitude_upper: float | None = None
+    time_start: float | None = None
+    time_end: float | None = None
+
+
+class OperationalIntentReference(BaseModel):
+    """A DSS op-intent reference: enough to fetch the peer's details."""
+
+    id: str
+    uss_base_url: str | None = None
+    ovn: str | None = None
+    state: str | None = None
+    manager: str | None = None
+    uss_availability: str | None = None
+
+
+class PeerOperationalIntentDetails(BaseModel):
+    """Op-intent details fetched from a peer USS (the volumes feed deconfliction)."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    volumes: list[Volume4D] = []
+    reference: OperationalIntentReference | None = None

--- a/src/flight_blender/schemas/flight_declaration.py
+++ b/src/flight_blender/schemas/flight_declaration.py
@@ -18,9 +18,15 @@ class FlightDeclarationBBoxRequest(BaseModel):
     maxy: float
 
 
+from flight_blender.common.datetime_utils import parse_iso_utc
+
+
 def _parse_utc(value: str) -> datetime:
-    dt = datetime.fromisoformat(value)
-    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    """Parse an ISO-8601 string into a timezone-aware UTC datetime (raises on failure)."""
+    result = parse_iso_utc(value)
+    if result is None:
+        raise ValueError(f"Invalid datetime: {value!r}")
+    return result
 
 
 def _validate_date_window(start_raw: str, end_raw: str) -> None:

--- a/src/flight_blender/schemas/geo_fence.py
+++ b/src/flight_blender/schemas/geo_fence.py
@@ -45,6 +45,7 @@ class GeoFenceResponse(BaseModel):
     name: str
     bounds: str
     status: int
+    message: str | None = None
     is_test_dataset: bool
     start_datetime: datetime
     end_datetime: datetime
@@ -60,29 +61,46 @@ class GeoFenceListResponse(BaseModel):
 
 
 class GeoZoneQueryRequest(BaseModel):
-    """ED-269 geo-awareness query."""
+    """InterUSS ED-269 geo-awareness map query.
 
-    volumes: list[dict[str, Any]]
-    after: datetime | None = None
-    before: datetime | None = None
+    The InterUSS qualifier posts ``{"checks": [{"filter_sets": [...]}]}``. Each
+    filter set may carry a ``position`` (a ``[lon, lat]`` pair), an ``after`` /
+    ``before`` time window, and/or an ``ed269`` block. All fields are optional so
+    an empty ``checks`` array is accepted (and resolves to ``Absent``).
+    """
+
+    checks: list[dict[str, Any]] = Field(default_factory=list)
 
 
-class GeoAwarenessStatusResponse(BaseModel):
-    result: str
+class GeoZoneCheckResult(BaseModel):
+    geozone: str
+
+
+class GeoZoneChecksResponse(BaseModel):
+    applicableGeozone: list[GeoZoneCheckResult]  # noqa: N815 - ED-269 wire name
     message: str | None = None
 
 
-class GeospatialDataSourceCreate(BaseModel):
+class GeoAwarenessStatusResponse(BaseModel):
+    """ED-269 geo-awareness test-harness status."""
+
+    status: str
+    api_version: str = "latest"
+
+
+class GeoZoneHttpsSource(BaseModel):
     url: str
-    name: str
-    description: str = ""
+    format: str = "ED-269"
 
 
-class GeospatialDataSourceResponse(BaseModel):
-    id: uuid.UUID
-    url: str
-    name: str
-    description: str
-    created_at: datetime
+class GeoZoneSourceRequest(BaseModel):
+    """InterUSS geospatial data source create/update body."""
 
-    model_config = {"from_attributes": True}
+    https_source: GeoZoneHttpsSource
+
+
+class GeoAwarenessTestStatus(BaseModel):
+    """Status record stored per geozone source id."""
+
+    result: str
+    message: str = ""

--- a/src/flight_blender/schemas/rid.py
+++ b/src/flight_blender/schemas/rid.py
@@ -19,7 +19,9 @@ class ISASubscriptionResponse(BaseModel):
     subscription_id: str
     view: str
     end_datetime: datetime
-    view_hash: str
+    # Nullable to match Django's ``view_hash`` (null=True). FastAPI computes a
+    # string SHA-256 digest; the column is a String, not an Integer.
+    view_hash: str | None = None
     is_simulated: bool
     created_at: datetime
 

--- a/src/flight_blender/schemas/uss.py
+++ b/src/flight_blender/schemas/uss.py
@@ -34,9 +34,13 @@ class ConstraintDetailsResponse(BaseModel):
 
 
 class USSFlightResponse(BaseModel):
+    """ASTM F3411 ``GetFlightsResponse`` shape (peer-USS RID data exchange)."""
+
+    timestamp: dict[str, Any] | None = None
     flights: list[dict[str, Any]]
 
 
 class USSFlightDetailResponse(BaseModel):
-    id: str
+    """ASTM F3411 ``GetFlightDetailsResponse`` shape (``{"details": {...}}``)."""
+
     details: dict[str, Any]

--- a/src/flight_blender/schemas/weather.py
+++ b/src/flight_blender/schemas/weather.py
@@ -5,7 +5,7 @@ Pydantic schemas for weather monitoring.
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class WeatherRequest(BaseModel):
@@ -16,7 +16,23 @@ class WeatherRequest(BaseModel):
 
 
 class WeatherResponse(BaseModel):
-    latitude: float
-    longitude: float
-    current_weather: dict[str, Any] | None = None
+    """Weather forecast response mirroring the Django ``WeatherSerializer`` shape.
+
+    Emits exactly the serializer's declared fields (latitude, longitude,
+    generationtime_ms, utc_offset_seconds, timezone, timezone_abbreviation,
+    elevation, hourly_units, hourly). Like the DRF serializer, undeclared
+    upstream keys (e.g. ``current_weather``) are dropped (``extra="ignore"``).
+    Fields are optional so partial upstream payloads validate without error.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    latitude: float | None = None
+    longitude: float | None = None
+    generationtime_ms: float | None = None
+    utc_offset_seconds: int | None = None
+    timezone: str | None = None
+    timezone_abbreviation: str | None = None
+    elevation: float | None = None
+    hourly_units: dict[str, Any] | None = None
     hourly: dict[str, Any] | None = None

--- a/src/flight_blender/services/conformance_engine.py
+++ b/src/flight_blender/services/conformance_engine.py
@@ -147,11 +147,7 @@ class OperationalIntentSnapshot:
     operational_intent_reference_exists: bool = True
 
 
-def _aware(value: datetime) -> datetime:
-    """Coerce a datetime to timezone-aware UTC for safe comparison."""
-    if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value
+from flight_blender.common.datetime_utils import ensure_utc as _aware
 
 
 def is_time_between(begin_time: datetime, end_time: datetime, check_time: datetime) -> bool:
@@ -169,28 +165,7 @@ def is_time_between(begin_time: datetime, end_time: datetime, check_time: dateti
     return check_time >= begin_time or check_time <= end_time
 
 
-def point_in_polygon(lng: float, lat: float, vertices: list[tuple[float, float]]) -> bool:
-    """Return whether the point (lng, lat) lies inside the polygon.
-
-    Pure-Python ray-casting (even-odd rule), equivalent to shapely's
-    ``Point(lng, lat).within(Polygon(vertices))``. ``vertices`` is a list of
-    (lng, lat) tuples; the ring is treated as closed (the last vertex is
-    implicitly joined back to the first).
-    """
-    n = len(vertices)
-    if n < 3:
-        return False
-    inside = False
-    j = n - 1
-    for i in range(n):
-        xi, yi = vertices[i]
-        xj, yj = vertices[j]
-        # Does the horizontal ray from the point cross edge (j -> i)?
-        intersects = ((yi > lat) != (yj > lat)) and (lng < (xj - xi) * (lat - yi) / (yj - yi) + xi)
-        if intersects:
-            inside = not inside
-        j = i
-    return inside
+from flight_blender.common.geometry import point_in_polygon  # re-exported for backward compat
 
 
 def check_operation_conformant_via_telemetry(

--- a/src/flight_blender/services/conformance_engine.py
+++ b/src/flight_blender/services/conformance_engine.py
@@ -1,0 +1,294 @@
+"""
+Pure conformance check engine (C2-C11).
+
+This is a faithful FastAPI port of the Django
+``conformance_monitoring_operations.utils.FlightBlenderConformanceEngine``.
+
+The original Django engine read directly from the database and the live
+telemetry stream inside its methods, which made it impossible to unit test.
+Here the decision logic is expressed as **pure functions** that take their
+inputs as plain values / dataclasses, so the C2-C11 checks can be exercised
+in isolation. The Celery task layer is responsible for loading the
+declaration, telemetry and geofences and feeding them into these functions.
+
+Geometry note: the Django engine used shapely's ``Point.within(Polygon)`` for
+the horizontal volume / geofence checks. shapely happens to be importable in
+the current project venv (2.1.x), but it is deliberately NOT declared in this
+FastAPI project's ``pyproject.toml`` or ``uv.lock`` -- it is only present
+incidentally and would disappear on a clean ``uv sync``. Rather than depend on
+an undeclared package (or modify dependency files that are outside the
+conformance scope), the equivalent point-in-polygon test is implemented here
+with a self-contained ray-casting algorithm. The semantics match the Django
+check (a point strictly inside the polygon is "within"). If shapely is later
+added as a first-class dependency, ``point_in_polygon`` can be swapped for
+``Point(lng, lat).within(Polygon(vertices))`` without changing any call site.
+
+Conformance vocabulary (mirrors Django ``ConformanceChecksList``):
+
+    C2  - Flight authorization / operational intent reference not granted
+    C3  - Telemetry aircraft-id does not match the authorization
+    C4  - Operation state invalid (Not Submitted / Ended / Withdrawn /
+          Cancelled / Rejected)
+    C5  - Operation accepted but not yet activated
+    C6  - Telemetry timestamp outside the operation start/end window
+    C7a - Aircraft outside the horizontal (4D volume) footprint
+    C7b - Aircraft outside the volume altitude band
+    C8  - Aircraft breaching an active geofence
+    C9a - No telemetry received at all (contingent)
+    C9b - Telemetry not received within the liveness window
+    C10 - Operation state not in {Activated, Nonconforming, Contingent}
+    C11 - No operational intent reference / flight authorization
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import IntEnum
+
+from flight_blender.common.enums import ACTIVE_OPERATIONAL_STATES, OperationState
+
+# States that make an operation invalid for telemetry conformance (Django C4):
+# Not Submitted (0), Ended (5), Withdrawn (6), Cancelled (7), Rejected (8).
+_INVALID_TELEMETRY_STATES: frozenset[int] = frozenset(
+    {
+        int(OperationState.NOT_SUBMITTED),
+        int(OperationState.ENDED),
+        int(OperationState.WITHDRAWN),
+        int(OperationState.CANCELLED),
+        int(OperationState.REJECTED),
+    }
+)
+
+# States in which the operation is considered actively airborne (Django [2, 3, 4]).
+_ACTIVE_STATES: frozenset[int] = frozenset(int(s) for s in ACTIVE_OPERATIONAL_STATES)
+
+# Liveness window for the most-recent telemetry (Django used +/- 15 seconds).
+TELEMETRY_LIVENESS_WINDOW = timedelta(seconds=15)
+
+
+class ConformanceCheck(IntEnum):
+    """The engine's return vocabulary.
+
+    ``CONFORMANT`` is the success sentinel. The Django engine used ``100`` for a
+    telemetry-conformant operation and ``1`` for an op-intent-conformant one; a
+    single explicit sentinel is clearer for callers, and the numeric C-codes are
+    preserved so they can be mapped back onto the legacy values if needed.
+    """
+
+    CONFORMANT = 1
+    C2 = 2
+    C3 = 3
+    C4 = 4
+    C5 = 5
+    C6 = 6
+    C7a = 7
+    C7b = 8
+    C8 = 9
+    C9a = 10
+    C9b = 11
+    C10 = 12
+    C11 = 13
+
+
+# Human-readable labels, mirroring Django ``ConformanceChecksList.options``.
+CONFORMANCE_CHECK_LABELS: dict[ConformanceCheck, str] = {
+    ConformanceCheck.CONFORMANT: "Conformant",
+    ConformanceCheck.C2: "Flight Auth not granted",
+    ConformanceCheck.C3: "Telemetry Auth mismatch",
+    ConformanceCheck.C4: "Operation state invalid",
+    ConformanceCheck.C5: "Operation not activated",
+    ConformanceCheck.C6: "Telemetry time incorrect",
+    ConformanceCheck.C7a: "Flight out of bounds",
+    ConformanceCheck.C7b: "Flight altitude out of bounds",
+    ConformanceCheck.C8: "Geofence breached",
+    ConformanceCheck.C9a: "Telemetry not received",
+    ConformanceCheck.C9b: "Telemetry not received within liveness window",
+    ConformanceCheck.C10: "State not in activated, non-conforming, contingent",
+    ConformanceCheck.C11: "No Flight Authorization",
+}
+
+
+@dataclass
+class VolumeBound:
+    """A horizontal polygon footprint plus its altitude band (metres, WGS84)."""
+
+    vertices: list[tuple[float, float]]  # (lng, lat) pairs
+    altitude_lower: float
+    altitude_upper: float
+
+
+@dataclass
+class GeoFencePolygon:
+    """A single geofence polygon ring as (lng, lat) vertices."""
+
+    vertices: list[tuple[float, float]]
+
+
+@dataclass
+class TelemetryObservation:
+    """A single telemetry position report."""
+
+    aircraft_id: str
+    lat: float
+    lng: float
+    altitude_m_wgs_84: float
+
+
+@dataclass
+class OperationalIntentSnapshot:
+    """The declaration / operational-intent state needed for telemetry checks."""
+
+    aircraft_id: str
+    state: int
+    start_datetime: datetime
+    end_datetime: datetime
+    volumes: list[VolumeBound] = field(default_factory=list)
+    operational_intent_reference_exists: bool = True
+
+
+def _aware(value: datetime) -> datetime:
+    """Coerce a datetime to timezone-aware UTC for safe comparison."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def is_time_between(begin_time: datetime, end_time: datetime, check_time: datetime) -> bool:
+    """Return whether ``check_time`` falls within [begin_time, end_time].
+
+    Ported from the Django helper of the same name, including the
+    crosses-midnight branch.
+    """
+    begin_time = _aware(begin_time)
+    end_time = _aware(end_time)
+    check_time = _aware(check_time)
+    if begin_time < end_time:
+        return begin_time <= check_time <= end_time
+    # crosses midnight
+    return check_time >= begin_time or check_time <= end_time
+
+
+def point_in_polygon(lng: float, lat: float, vertices: list[tuple[float, float]]) -> bool:
+    """Return whether the point (lng, lat) lies inside the polygon.
+
+    Pure-Python ray-casting (even-odd rule), equivalent to shapely's
+    ``Point(lng, lat).within(Polygon(vertices))``. ``vertices`` is a list of
+    (lng, lat) tuples; the ring is treated as closed (the last vertex is
+    implicitly joined back to the first).
+    """
+    n = len(vertices)
+    if n < 3:
+        return False
+    inside = False
+    j = n - 1
+    for i in range(n):
+        xi, yi = vertices[i]
+        xj, yj = vertices[j]
+        # Does the horizontal ray from the point cross edge (j -> i)?
+        intersects = ((yi > lat) != (yj > lat)) and (lng < (xj - xi) * (lat - yi) / (yj - yi) + xi)
+        if intersects:
+            inside = not inside
+        j = i
+    return inside
+
+
+def check_operation_conformant_via_telemetry(
+    *,
+    snapshot: OperationalIntentSnapshot,
+    telemetry: TelemetryObservation,
+    geofences: list[GeoFencePolygon],
+    now: datetime | None = None,
+    ussp_network_enabled: bool = False,
+) -> ConformanceCheck:
+    """Run the telemetry-driven conformance sequence (C2-C8).
+
+    Returns :data:`ConformanceCheck.CONFORMANT` when every check passes, or the
+    first failing C-code otherwise. The check order matches the Django engine.
+    """
+    now = _aware(now) if now is not None else datetime.now(timezone.utc)
+
+    # C2: flight authorization / operational intent reference exists.
+    # Django only enforced this when the USSP network was enabled; with the
+    # network disabled the reference is treated as implicitly present.
+    if ussp_network_enabled and not snapshot.operational_intent_reference_exists:
+        return ConformanceCheck.C2
+
+    # C3: telemetry aircraft id matches the declared aircraft id.
+    if snapshot.aircraft_id != telemetry.aircraft_id:
+        return ConformanceCheck.C3
+
+    # C4: operation is not in an invalid state.
+    if snapshot.state in _INVALID_TELEMETRY_STATES:
+        return ConformanceCheck.C4
+
+    # C5: operation is activated (or nonconforming / contingent).
+    if snapshot.state not in _ACTIVE_STATES:
+        return ConformanceCheck.C5
+
+    # C6: telemetry timestamp within the operation time window.
+    if not is_time_between(snapshot.start_datetime, snapshot.end_datetime, now):
+        return ConformanceCheck.C6
+
+    # C7a / C7b: aircraft within the 4D volume (footprint + altitude band).
+    bounds_conformant = False
+    altitude_conformant = False
+    for volume in snapshot.volumes:
+        if point_in_polygon(telemetry.lng, telemetry.lat, volume.vertices):
+            bounds_conformant = True
+        if volume.altitude_lower <= telemetry.altitude_m_wgs_84 <= volume.altitude_upper:
+            altitude_conformant = True
+
+    # Django checks altitude (C7b) before horizontal bounds (C7a).
+    if not altitude_conformant:
+        return ConformanceCheck.C7b
+    if not bounds_conformant:
+        return ConformanceCheck.C7a
+
+    # C8: aircraft not breaching an active geofence.
+    for geofence in geofences:
+        if point_in_polygon(telemetry.lng, telemetry.lat, geofence.vertices):
+            return ConformanceCheck.C8
+
+    return ConformanceCheck.CONFORMANT
+
+
+def check_operational_intent_reference_conformance(
+    *,
+    state: int,
+    latest_telemetry_datetime: datetime | None,
+    operational_intent_reference_exists: bool = True,
+    now: datetime | None = None,
+    ussp_network_enabled: bool = False,
+    liveness_window: timedelta = TELEMETRY_LIVENESS_WINDOW,
+) -> ConformanceCheck:
+    """Run the telemetry-independent conformance sequence (C9-C11).
+
+    Mirrors Django ``check_flight_operational_intent_reference_conformance``:
+
+    * C11 - operational intent reference missing (only when USSP enabled).
+    * C10 - operation state not in {Activated, Nonconforming, Contingent}.
+    * C9a - no telemetry has ever been received.
+    * C9b - telemetry exists but is older than the liveness window.
+    """
+    now = _aware(now) if now is not None else datetime.now(timezone.utc)
+
+    # C11: operational intent reference exists (only checked on USSP network).
+    if ussp_network_enabled and not operational_intent_reference_exists:
+        return ConformanceCheck.C11
+
+    # C10: operation state is one in which the operation is active.
+    if state not in _ACTIVE_STATES:
+        return ConformanceCheck.C10
+
+    # C9a / C9b: telemetry liveness.
+    if latest_telemetry_datetime is None:
+        return ConformanceCheck.C9a
+
+    latest = _aware(latest_telemetry_datetime)
+    window_start = now - liveness_window
+    window_end = now + liveness_window
+    if not (window_start <= latest <= window_end):
+        return ConformanceCheck.C9b
+
+    return ConformanceCheck.CONFORMANT

--- a/src/flight_blender/services/deconfliction.py
+++ b/src/flight_blender/services/deconfliction.py
@@ -1,9 +1,25 @@
-"""Deconfliction engine protocol and default R-tree implementation.
+"""Deconfliction engine protocol and default implementation.
 
-The DefaultDeconflictionEngine performs in-memory R-tree bounding-box checks
-against pre-fetched geofences and flight declarations.  The router is
-responsible for querying the database and passing the results via
-DeconflictionRequest.prefetched_fences / prefetched_declarations.
+The DefaultDeconflictionEngine performs strategic conflict detection between a
+candidate operational intent and the set of existing / peer operational
+intents.  Two checking modes are supported:
+
+* **Volume mode** (preferred): full 4D strategic deconfliction — a conflict
+  requires overlap in space *and* time *and* altitude.  Geometry is pure
+  Python (ray-casting point-in-polygon, matching the style of
+  ``services/conformance_engine.py``); shapely is deliberately not used.
+* **Bbox mode** (legacy/fallback): in-memory R-tree bounding-box checks against
+  pre-fetched geofences and flight declarations.  This mirrors the Django
+  ``DefaultDeconflictionEngine`` (``flight_declaration_operations/
+  deconfliction_engine.py``) exactly.
+
+The router is responsible for querying the database and passing the results via
+the DeconflictionRequest fields.
+
+Safety note: strategic deconfliction must *fail closed*.  When the engine
+cannot produce a trustworthy answer (import error, malformed geometry, etc.)
+the decision logic refuses approval rather than accepting by default.  See
+``resolve_decision``.
 """
 
 from __future__ import annotations
@@ -11,9 +27,12 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Protocol, runtime_checkable
 
 from loguru import logger
+
+from flight_blender.common.enums import OperationState
 
 try:
     from rtree import index as _rtree_index
@@ -23,6 +42,120 @@ except ImportError:  # pragma: no cover
     _rtree_index = None  # type: ignore[assignment]
     _RTREE_AVAILABLE = False
     logger.warning("rtree library not installed — falling back to pure-Python bbox deconfliction")
+
+
+# ── Pure geometric / temporal / altitude helpers ───────────────────────────
+
+
+def _point_in_polygon(pt: list[float], poly: list[list[float]]) -> bool:
+    """Ray-casting (even-odd) point-in-polygon for [lon, lat] coordinates."""
+    n = len(poly)
+    if n < 3:
+        return False
+    x, y = pt[0], pt[1]
+    inside = False
+    j = n - 1
+    for i in range(n):
+        xi, yi = poly[i][0], poly[i][1]
+        xj, yj = poly[j][0], poly[j][1]
+        if ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi):
+            inside = not inside
+        j = i
+    return inside
+
+
+def check_polygon_intersection(polygon_a: list[list[float]], polygon_b: list[list[float]]) -> bool:
+    """Return True when two polygons (lists of [lon, lat]) overlap.
+
+    Uses a bounding-box quick-reject followed by mutual vertex containment.
+    Pure Python — no third-party geometry deps.
+    """
+    if len(polygon_a) < 3 or len(polygon_b) < 3:
+        return False
+
+    def _bbox(coords: list[list[float]]) -> tuple[float, float, float, float]:
+        xs = [c[0] for c in coords]
+        ys = [c[1] for c in coords]
+        return min(xs), min(ys), max(xs), max(ys)
+
+    ax0, ay0, ax1, ay1 = _bbox(polygon_a)
+    bx0, by0, bx1, by1 = _bbox(polygon_b)
+
+    # bbox quick-reject
+    if ax1 < bx0 or bx1 < ax0 or ay1 < by0 or by1 < ay0:
+        return False
+
+    for pt in polygon_a:
+        if _point_in_polygon(pt, polygon_b):
+            return True
+    for pt in polygon_b:
+        if _point_in_polygon(pt, polygon_a):
+            return True
+    return False
+
+
+def check_time_overlap(start_a: datetime, end_a: datetime, start_b: datetime, end_b: datetime) -> bool:
+    """Return True when two (closed) time intervals overlap or touch."""
+    return start_a <= end_b and start_b <= end_a
+
+
+def check_altitude_overlap(min_a: float, max_a: float, min_b: float, max_b: float) -> bool:
+    """Return True when two (closed) altitude bands overlap or touch."""
+    return min_a <= max_b and min_b <= max_a
+
+
+def _coerce_dt(value: object) -> datetime | None:
+    """Best-effort coercion of an ISO string / datetime into a datetime."""
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def deconflict_operational_intent(candidate: dict, existing_volumes: list[dict]) -> bool:
+    """Full strategic deconfliction.
+
+    Returns True when the candidate is **CLEAR** (no conflict) against every
+    existing volume, considering space + time + altitude.  A pairwise overlap in
+    *all three* dimensions constitutes a conflict and returns False.
+
+    Each volume dict has keys: ``coordinates`` (list of [lon, lat]),
+    ``min_alt``, ``max_alt``, ``start``, ``end`` (datetime or ISO string).
+    """
+    cand_start = _coerce_dt(candidate.get("start"))
+    cand_end = _coerce_dt(candidate.get("end"))
+    cand_coords = candidate.get("coordinates") or []
+
+    for existing in existing_volumes:
+        ex_start = _coerce_dt(existing.get("start"))
+        ex_end = _coerce_dt(existing.get("end"))
+
+        # temporal — only enforce when both windows are known
+        if cand_start and cand_end and ex_start and ex_end:
+            if not check_time_overlap(cand_start, cand_end, ex_start, ex_end):
+                continue
+
+        # altitude
+        if not check_altitude_overlap(
+            candidate.get("min_alt", float("-inf")),
+            candidate.get("max_alt", float("inf")),
+            existing.get("min_alt", float("-inf")),
+            existing.get("max_alt", float("inf")),
+        ):
+            continue
+
+        # spatial
+        if check_polygon_intersection(cand_coords, existing.get("coordinates") or []):
+            return False  # conflict found
+
+    return True  # clear
+
+
+# ── Legacy bbox helpers (faithful Django port) ──────────────────────────────
 
 
 def _parse_bounds(bounds_str: str) -> tuple[float, float, float, float] | None:
@@ -69,6 +202,9 @@ def _check_rtree(view_box: list[float], items: list[dict], id_field: str) -> lis
     return results
 
 
+# ── Data classes ────────────────────────────────────────────────────────────
+
+
 @dataclass
 class DeconflictionRequest:
     declaration_id: str | None = None
@@ -79,7 +215,10 @@ class DeconflictionRequest:
     ussp_network_enabled: int = 0
     type_of_operation: int = 0
     priority: int = 0
-    # Pre-fetched spatial data — populated by the router before calling the engine
+    # Volume mode — full 4D strategic deconfliction
+    candidate_volume: dict | None = None
+    prefetched_volumes: list[dict] = field(default_factory=list)
+    # Pre-fetched spatial data — populated by the router for legacy bbox mode
     prefetched_fences: list[dict] = field(default_factory=list)  # [{id: str, bounds: str}, ...]
     prefetched_declarations: list[dict] = field(default_factory=list)  # [{id: str, bounds: str}, ...]
 
@@ -92,6 +231,36 @@ class DeconflictionResult:
     declaration_state: int = 1  # Accepted
 
 
+@dataclass
+class DeconflictionDecision:
+    """Outcome of mapping (clear?/error?/network?) → (approval, db state)."""
+
+    is_approved: bool
+    declaration_state: int
+
+
+def resolve_decision(*, engine_error: bool, is_clear: bool, ussp_network_enabled: int | bool) -> DeconflictionDecision:
+    """Pure, fail-closed decision logic for strategic deconfliction.
+
+    Mirrors the Django acceptance path
+    (``flight_declaration_operations/deconfliction_engine.py`` +
+    ``views.py``):
+
+    * engine error  → never approved, Rejected (fail closed — safety critical).
+    * conflict      → not approved, Rejected (state 8).
+    * clear + USSP  → approved, NotSubmitted (state 0) — pending DSS submission.
+    * clear, no USSP→ approved, Accepted (state 1).
+    """
+    if engine_error or not is_clear:
+        return DeconflictionDecision(is_approved=False, declaration_state=int(OperationState.REJECTED))
+    if ussp_network_enabled:
+        return DeconflictionDecision(is_approved=True, declaration_state=int(OperationState.NOT_SUBMITTED))
+    return DeconflictionDecision(is_approved=True, declaration_state=int(OperationState.ACCEPTED))
+
+
+# ── Protocol + engine ───────────────────────────────────────────────────────
+
+
 @runtime_checkable
 class DeconflictionEngine(Protocol):
     """Protocol that all deconfliction engine plugins must satisfy."""
@@ -100,51 +269,65 @@ class DeconflictionEngine(Protocol):
 
 
 class DefaultDeconflictionEngine:
-    """Built-in R-tree bounding-box deconfliction engine.
+    """Built-in strategic deconfliction engine.
 
-    Mirrors the Django DefaultDeconflictionEngine logic:
-    1. Check geofence bbox conflicts via R-tree.
-    2. Check active flight declaration bbox conflicts via R-tree.
-    3. Any intersection → rejected (state 8, is_approved=False).
+    Volume mode (when ``candidate_volume`` is supplied): full 4D check via
+    ``deconflict_operational_intent``.  Bbox mode (otherwise): R-tree
+    bounding-box checks against pre-fetched geofences and declarations,
+    mirroring the Django engine.
 
-    Requires DeconflictionRequest.prefetched_fences and
-    prefetched_declarations to be populated by the caller.
+    Any conflict → rejected (state 8, is_approved=False).  A clear result maps
+    via ``resolve_decision`` so the USSP gate is honoured consistently.
     """
 
     def check_deconfliction(self, request: DeconflictionRequest) -> DeconflictionResult:
+        if request.candidate_volume is not None:
+            return self._check_volumes(request)
+        return self._check_bbox(request)
+
+    # — Volume (4D) strategic mode —
+    def _check_volumes(self, request: DeconflictionRequest) -> DeconflictionResult:
+        is_clear = deconflict_operational_intent(request.candidate_volume or {}, request.prefetched_volumes)
+        if not is_clear:
+            logger.info("Deconfliction: candidate conflicts with an existing operational intent")
+        decision = resolve_decision(
+            engine_error=False,
+            is_clear=is_clear,
+            ussp_network_enabled=request.ussp_network_enabled,
+        )
+        return DeconflictionResult(
+            is_approved=decision.is_approved,
+            declaration_state=decision.declaration_state,
+        )
+
+    # — Legacy bbox mode (faithful Django port) —
+    def _check_bbox(self, request: DeconflictionRequest) -> DeconflictionResult:
         view_box = request.view_box
-        is_approved = True
-        declaration_state = 0 if request.ussp_network_enabled else 1
 
         all_relevant_fences: list[str] = []
         all_relevant_declarations: list[str] = []
 
         if not view_box or len(view_box) < 4:
             logger.debug("Deconfliction skipped: no view_box provided")
-            return DeconflictionResult(
-                is_approved=is_approved,
-                declaration_state=declaration_state,
-            )
+            decision = resolve_decision(engine_error=False, is_clear=True, ussp_network_enabled=request.ussp_network_enabled)
+            return DeconflictionResult(is_approved=decision.is_approved, declaration_state=decision.declaration_state)
 
-        # ── GeoFence check ───────────────────────────────────────────────
         if request.prefetched_fences:
             all_relevant_fences = _check_rtree(view_box, request.prefetched_fences, "id")
-            if all_relevant_fences:
-                logger.info("Deconfliction: {} geofence(s) conflict", len(all_relevant_fences))
-                is_approved = False
-                declaration_state = 8
-
-        # ── Flight declaration check ─────────────────────────────────────
-        if request.prefetched_declarations and is_approved:
+        if request.prefetched_declarations:
             all_relevant_declarations = _check_rtree(view_box, request.prefetched_declarations, "id")
-            if all_relevant_declarations:
-                logger.info("Deconfliction: {} declaration(s) conflict", len(all_relevant_declarations))
-                is_approved = False
-                declaration_state = 8
 
+        is_clear = not (all_relevant_fences or all_relevant_declarations)
+        if not is_clear:
+            logger.info(
+                "Deconfliction: {} fence(s), {} declaration(s) conflict",
+                len(all_relevant_fences),
+                len(all_relevant_declarations),
+            )
+        decision = resolve_decision(engine_error=False, is_clear=is_clear, ussp_network_enabled=request.ussp_network_enabled)
         return DeconflictionResult(
             all_relevant_fences=all_relevant_fences,
             all_relevant_declarations=all_relevant_declarations,
-            is_approved=is_approved,
-            declaration_state=declaration_state,
+            is_approved=decision.is_approved,
+            declaration_state=decision.declaration_state,
         )

--- a/src/flight_blender/services/deconfliction.py
+++ b/src/flight_blender/services/deconfliction.py
@@ -47,21 +47,12 @@ except ImportError:  # pragma: no cover
 # ── Pure geometric / temporal / altitude helpers ───────────────────────────
 
 
+from flight_blender.common.geometry import point_in_polygon as _pip
+
+
 def _point_in_polygon(pt: list[float], poly: list[list[float]]) -> bool:
-    """Ray-casting (even-odd) point-in-polygon for [lon, lat] coordinates."""
-    n = len(poly)
-    if n < 3:
-        return False
-    x, y = pt[0], pt[1]
-    inside = False
-    j = n - 1
-    for i in range(n):
-        xi, yi = poly[i][0], poly[i][1]
-        xj, yj = poly[j][0], poly[j][1]
-        if ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi):
-            inside = not inside
-        j = i
-    return inside
+    """Adapter: call shared ``point_in_polygon`` with the deconfliction data shapes."""
+    return _pip(pt[0], pt[1], [(p[0], p[1]) for p in poly])
 
 
 def check_polygon_intersection(polygon_a: list[list[float]], polygon_b: list[list[float]]) -> bool:
@@ -108,12 +99,9 @@ def _coerce_dt(value: object) -> datetime | None:
     """Best-effort coercion of an ISO string / datetime into a datetime."""
     if isinstance(value, datetime):
         return value
-    if isinstance(value, str):
-        try:
-            return datetime.fromisoformat(value)
-        except ValueError:
-            return None
-    return None
+    from flight_blender.common.datetime_utils import parse_iso_utc
+
+    return parse_iso_utc(value)
 
 
 def deconflict_operational_intent(candidate: dict, existing_volumes: list[dict]) -> bool:

--- a/src/flight_blender/services/peer_uss_client.py
+++ b/src/flight_blender/services/peer_uss_client.py
@@ -32,7 +32,7 @@ from typing import Any
 import requests
 from loguru import logger
 
-from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
+from flight_blender.auth.dss import get_dss_auth_header
 from flight_blender.config import get_settings
 from flight_blender.schemas.deconfliction import (
     LatLng,
@@ -48,10 +48,7 @@ _REQUEST_TIMEOUT = 30
 
 def _auth_header(token_type: str = "scd") -> dict[str, str]:
     """Build the Authorization header using the DSS token helper."""
-    getter = AuthorityCredentialsGetter()
-    credentials = getter.get_cached_credentials(audience=settings.dss_auth_audience, token_type=token_type)
-    access_token = credentials.get("access_token", "") if isinstance(credentials, dict) else ""
-    return {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
+    return get_dss_auth_header(audience=settings.dss_auth_audience, token_type=token_type)
 
 
 # ── P1: peer op-intent details GET ───────────────────────────────────────────

--- a/src/flight_blender/services/peer_uss_client.py
+++ b/src/flight_blender/services/peer_uss_client.py
@@ -1,0 +1,238 @@
+"""
+Peer-USS / DSS operational-intent client (migrated from Django
+scd_operations/dss_scd_helper.py).
+
+This module implements the *testable* request-construction and response-parsing
+logic for three peer-USS / DSS interactions used by strategic deconfliction and
+op-intent submission:
+
+* :func:`get_peer_operational_intent_details` -- authenticated GET to a peer
+  USS's ``/uss/v1/operational_intents/{id}`` endpoint, parsing the returned
+  operational-intent details into :class:`PeerOperationalIntentDetails`
+  (volumes) that feed strategic deconfliction.
+* :func:`collect_ovns` / :func:`build_operational_intent_reference_payload` --
+  pure logic that collects the OVNs of overlapping op-intent references returned
+  by the DSS area query to build the ``key`` list and constructs non-empty
+  ``extents`` from the operation's volumes for DSS op-intent reference writes.
+* :func:`build_peer_notification_payload` / :func:`notify_peer_uss` -- the
+  ``POST /uss/v1/operational_intents`` notification request to inform a
+  subscriber USS of a created/updated op-intent.
+
+The HTTP layer is the module-level ``requests`` import (mirroring
+``constraints_client``), which tests patch. The raw network send is gated behind
+``settings.ussp_network_enabled`` for the notification path; the GET details
+call is only exercised behind the patched/gated submission flow. No live DSS I/O
+is performed in the test-suite.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from loguru import logger
+
+from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
+from flight_blender.config import get_settings
+from flight_blender.schemas.deconfliction import (
+    LatLng,
+    OperationalIntentReference,
+    PeerOperationalIntentDetails,
+    Volume4D,
+)
+
+settings = get_settings()
+
+_REQUEST_TIMEOUT = 30
+
+
+def _auth_header(token_type: str = "scd") -> dict[str, str]:
+    """Build the Authorization header using the DSS token helper."""
+    getter = AuthorityCredentialsGetter()
+    credentials = getter.get_cached_credentials(audience=settings.dss_auth_audience, token_type=token_type)
+    access_token = credentials.get("access_token", "") if isinstance(credentials, dict) else ""
+    return {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
+
+
+# ── P1: peer op-intent details GET ───────────────────────────────────────────
+def _coerce_float(value: Any) -> float | None:
+    """Return *value* as a float, or ``None`` when it is not numeric."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _parse_volume(raw_volume: dict) -> Volume4D:
+    """Parse one ASTM op-intent ``volume`` entry into a :class:`Volume4D`."""
+    volume = raw_volume.get("volume", {}) if isinstance(raw_volume, dict) else {}
+
+    vertices = []
+    outline = volume.get("outline_polygon")
+    if isinstance(outline, dict):
+        for vertex in outline.get("vertices", []) or []:
+            if isinstance(vertex, dict) and "lat" in vertex and "lng" in vertex:
+                vertices.append(LatLng(lat=vertex["lat"], lng=vertex["lng"]))
+
+    def _altitude(key: str) -> float | None:
+        node = volume.get(key)
+        if isinstance(node, dict):
+            return _coerce_float(node.get("value"))
+        return _coerce_float(node)
+
+    def _time(key: str) -> float | None:
+        node = raw_volume.get(key)
+        if isinstance(node, dict):
+            return _coerce_float(node.get("value"))
+        return _coerce_float(node)
+
+    return Volume4D(
+        outline_polygon=vertices,
+        altitude_lower=_altitude("altitude_lower"),
+        altitude_upper=_altitude("altitude_upper"),
+        time_start=_time("time_start"),
+        time_end=_time("time_end"),
+    )
+
+
+def _parse_operational_intent_details(body: dict, reference: OperationalIntentReference) -> PeerOperationalIntentDetails:
+    """Parse a peer op-intent details response body into volumes."""
+    if not isinstance(body, dict):
+        return PeerOperationalIntentDetails(volumes=[], reference=reference)
+    operational_intent = body.get("operational_intent", {})
+    details = operational_intent.get("details", {}) if isinstance(operational_intent, dict) else {}
+    raw_volumes = details.get("volumes", []) if isinstance(details, dict) else []
+    volumes = [_parse_volume(raw) for raw in raw_volumes if isinstance(raw, dict)]
+    return PeerOperationalIntentDetails(volumes=volumes, reference=reference)
+
+
+def get_peer_operational_intent_details(reference: OperationalIntentReference) -> PeerOperationalIntentDetails:
+    """Fetch op-intent details from a peer USS and parse them into volumes.
+
+    Builds the authenticated GET to
+    ``{uss_base_url}/uss/v1/operational_intents/{id}`` and parses the response.
+    Returns an empty :class:`PeerOperationalIntentDetails` (no volumes) on a
+    missing base URL, a non-200 response, a network error, or a malformed body
+    -- mirroring the Django ``get_and_set_dss_operational_intent_details``
+    behaviour of returning ``{}`` rather than raising.
+    """
+    if not reference.uss_base_url:
+        logger.error("Peer op-intent details requested without a uss_base_url")
+        return PeerOperationalIntentDetails(volumes=[], reference=reference)
+
+    url = f"{reference.uss_base_url}/uss/v1/operational_intents/{reference.id}"
+    headers = _auth_header()
+    try:
+        response = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
+    except requests.RequestException as exc:
+        logger.error("Peer op-intent details request failed: %s", exc)
+        return PeerOperationalIntentDetails(volumes=[], reference=reference)
+
+    if response.status_code != 200:
+        logger.error("Peer op-intent details returned %s for %s", response.status_code, url)
+        return PeerOperationalIntentDetails(volumes=[], reference=reference)
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        logger.error("Peer op-intent details body was not JSON: %s", exc)
+        return PeerOperationalIntentDetails(volumes=[], reference=reference)
+
+    return _parse_operational_intent_details(body, reference)
+
+
+# ── P2: OVN / key / extents builder for DSS writes ───────────────────────────
+def collect_ovns(existing_references: list[dict]) -> list[str]:
+    """Collect the OVNs of overlapping op-intent references.
+
+    Mirrors the Django ``[ref["ovn"] for ref in operational_intent_references]``
+    used to populate the ``key`` of a DSS op-intent reference write. References
+    without a (non-null) ``ovn`` are skipped.
+    """
+    ovns: list[str] = []
+    for reference in existing_references or []:
+        if not isinstance(reference, dict):
+            continue
+        ovn = reference.get("ovn")
+        if ovn:
+            ovns.append(ovn)
+    return ovns
+
+
+def build_operational_intent_reference_payload(
+    volumes: list[dict],
+    state: str,
+    existing_references: list[dict],
+    uss_base_url: str,
+) -> dict:
+    """Build the DSS op-intent reference create/update payload.
+
+    Populates a non-empty ``extents`` from the operation's *volumes* and the
+    ``key`` from the OVNs of overlapping *existing_references* (the area-query
+    result), addressing the empty ``key``/``extents`` regression.
+    """
+    return {
+        "extents": volumes,
+        "key": collect_ovns(existing_references),
+        "state": state,
+        "uss_base_url": uss_base_url,
+        "new_subscription": {
+            "uss_base_url": uss_base_url,
+            "notify_for_constraints": False,
+        },
+    }
+
+
+# ── P3: peer notification POST builder + gated send ──────────────────────────
+def build_peer_notification_payload(
+    operational_intent_id: str,
+    operational_intent_details: dict,
+    ovn: str | None,
+    blender_base_url: str,
+    subscriptions: list[dict],
+) -> dict:
+    """Build the body for a ``POST /uss/v1/operational_intents`` notification.
+
+    Mirrors Django ``notify_peer_uss_of_created_or_updated_opint``: the
+    reference advertises Blender's own ``uss_base_url`` and the new OVN.
+    """
+    return {
+        "operational_intent_id": operational_intent_id,
+        "operational_intent": {
+            "reference": {
+                "id": operational_intent_id,
+                "ovn": ovn,
+                "uss_base_url": blender_base_url,
+            },
+            "details": operational_intent_details,
+        },
+        "subscriptions": subscriptions,
+    }
+
+
+def notify_peer_uss(uss_base_url: str, notification_payload: dict) -> bool:
+    """POST a notification to a subscriber USS about a created/updated op-intent.
+
+    Builds the authenticated POST to ``{uss_base_url}/uss/v1/operational_intents``.
+    The raw send is gated behind ``settings.ussp_network_enabled``; returns
+    ``True`` only on a 204 response (per the ASTM contract), ``False``
+    otherwise (gate off, non-204, or network error).
+    """
+    if not settings.ussp_network_enabled:
+        logger.info("USSP network disabled; skipping peer USS notification to %s", uss_base_url)
+        return False
+
+    url = f"{uss_base_url}/uss/v1/operational_intents"
+    headers = _auth_header()
+    try:
+        response = requests.post(url, json=notification_payload, headers=headers, timeout=_REQUEST_TIMEOUT)
+    except requests.RequestException as exc:
+        logger.error("Error notifying peer USS %s: %s", uss_base_url, exc)
+        return False
+
+    if response.status_code == 204:
+        logger.info("Successfully notified peer USS %s", uss_base_url)
+        return True
+    logger.error("Peer USS notification to %s returned %s", uss_base_url, response.status_code)
+    return False

--- a/src/flight_blender/services/state_machine.py
+++ b/src/flight_blender/services/state_machine.py
@@ -101,7 +101,9 @@ _REVERSE_MAP: dict[type[_State], int] = {v: k for k, v in _STATE_MAP.items()}
 TERMINAL_STATES: frozenset[int] = frozenset({5, 6, 7, 8})
 
 # States considered "active" for deconfliction intersection checks
-ACTIVE_OPERATIONAL_STATES: list[int] = [1, 2, 3, 4]
+from flight_blender.common.enums import VALID_OPERATIONAL_INTENT_STATES
+
+ACTIVE_OPERATIONAL_STATES: list[int] = list(VALID_OPERATIONAL_INTENT_STATES)
 
 
 def _make_state(state_int: int) -> _State:
@@ -131,11 +133,16 @@ def is_valid_transition(current_state: int, event: str) -> tuple[bool, int]:
 def get_valid_transitions() -> dict[int, list[str]]:
     """Return mapping of state_int → list of events that cause a transition."""
     events = [
-        "dss_accepts", "operator_withdraws", "operator_cancels",
-        "operator_activates", "operator_confirms_ended",
+        "dss_accepts",
+        "operator_withdraws",
+        "operator_cancels",
+        "operator_activates",
+        "operator_confirms_ended",
         "ua_departs_early_late_outside_op_intent",
-        "ua_exits_coordinated_op_intent", "operator_initiates_contingent",
-        "operator_return_to_coordinated_op_intent", "timeout",
+        "ua_exits_coordinated_op_intent",
+        "operator_initiates_contingent",
+        "operator_return_to_coordinated_op_intent",
+        "timeout",
         "operator_confirms_contingent",
     ]
     result: dict[int, list[str]] = {}

--- a/src/flight_blender/services/telemetry_verifier.py
+++ b/src/flight_blender/services/telemetry_verifier.py
@@ -5,12 +5,15 @@ Uses the http-message-signatures library (RFC 9421).
 """
 
 from __future__ import annotations
+from jwt.algorithms import RSAAlgorithm
+from http_message_signatures.resolvers import HTTPSignatureKeyResolver
+from flight_blender.models import SignedTelemetryPublicKey
+from typing import Iterable
 
 import base64
 import hashlib
 
-import jwt
-import requests
+import httpx
 from loguru import logger
 
 try:
@@ -50,14 +53,14 @@ def _content_digest_matches(headers: dict[str, str], body: bytes) -> bool:
     return False
 
 
-class _JWKKeyResolver:
+class _JWKKeyResolver(HTTPSignatureKeyResolver):
     """Resolve public keys from a JWK dict for HTTP message signature verification."""
 
     def __init__(self, jwk_data: dict) -> None:
         self._jwk = jwk_data
 
     def resolve_public_key(self, key_id: str | None = None):  # type: ignore[override]
-        return jwt.algorithms.RSAAlgorithm.from_jwk(self._jwk)
+        return RSAAlgorithm.from_jwk(self._jwk)
 
     def resolve_private_key(self, key_id: str) -> None:  # type: ignore[override]
         return None
@@ -114,29 +117,30 @@ async def verify_signed_request(
     return False
 
 
-def fetch_public_keys_from_db_rows(rows: list) -> dict[str, dict]:
+async def fetch_public_keys_from_db_rows(rows: Iterable[SignedTelemetryPublicKey]) -> dict[str, dict]:
     """Fetch and cache JWK data for a list of SignedTelemetryPublicKey model rows.
 
     Returns a mapping of key_id → JWK dict.
-    Uses a simple in-process requests.Session (no Redis in FastAPI path).
+    Uses an async ``httpx.AsyncClient`` so it can be called from async handlers
+    without blocking the event loop.
     """
-    session = requests.Session()
     result: dict[str, dict] = {}
 
-    for row in rows:
-        kid = row.key_id
-        try:
-            resp = session.get(row.url, timeout=5)
-            resp.raise_for_status()
-            jwks = resp.json()
-            jwk: dict | None = None
-            if "keys" in jwks:
-                jwk = next((k for k in jwks["keys"] if k.get("kid") == kid), None)
-            elif jwks.get("kid") == kid:
-                jwk = jwks
-            if jwk:
-                result[kid] = jwk
-        except Exception as exc:
-            logger.error("Failed to fetch public key {} from {}: {}", kid, row.url, exc)
+    async with httpx.AsyncClient(timeout=5) as client:
+        for row in rows:
+            kid = row.key_id
+            try:
+                resp = await client.get(row.url)
+                resp.raise_for_status()
+                jwks = resp.json()
+                jwk: dict | None = None
+                if "keys" in jwks:
+                    jwk = next((k for k in jwks["keys"] if k.get("kid") == kid), None)
+                elif jwks.get("kid") == kid:
+                    jwk = jwks
+                if jwk:
+                    result[kid] = jwk
+            except Exception as exc:
+                logger.error("Failed to fetch public key {} from {}: {}", kid, row.url, exc)
 
     return result

--- a/src/flight_blender/services/telemetry_verifier.py
+++ b/src/flight_blender/services/telemetry_verifier.py
@@ -6,7 +6,8 @@ Uses the http-message-signatures library (RFC 9421).
 
 from __future__ import annotations
 
-import json
+import base64
+import hashlib
 
 import jwt
 import requests
@@ -15,7 +16,6 @@ from loguru import logger
 try:
     from http_message_signatures import (
         HTTPMessageVerifier,
-        HTTPSignatureKeyResolver,
         algorithms,
     )
 
@@ -23,6 +23,31 @@ try:
 except ImportError:  # pragma: no cover
     _SIGNING_AVAILABLE = False
     logger.warning("http-message-signatures not installed — telemetry signature verification disabled")
+
+
+def _content_digest_matches(headers: dict[str, str], body: bytes) -> bool:
+    """Validate that the ``Content-Digest`` header binds *body* (RFC 9530).
+
+    The HTTP message signature covers the ``content-digest`` *header*, not the
+    raw body, so a signature can be replayed with a swapped body unless the
+    digest is independently checked against the body. We require a ``sha-256``
+    digest to be present and to match ``base64(sha256(body))``.
+    """
+    header = next((v for k, v in headers.items() if k.lower() == "content-digest"), None)
+    if not header:
+        # No digest to bind the body — refuse rather than trust an unbound signature.
+        return False
+
+    expected = base64.b64encode(hashlib.sha256(body).digest()).decode()
+    # Header is a Structured Field Dictionary, e.g. ``sha-256=:<b64>:``. Be lenient
+    # about ordering / additional algorithms and just look for our sha-256 value.
+    for member in header.split(","):
+        if "sha-256=" not in member.lower():
+            continue
+        value = member.split("=", 1)[1].strip().strip(":")
+        if value == expected:
+            return True
+    return False
 
 
 class _JWKKeyResolver:
@@ -57,7 +82,12 @@ async def verify_signed_request(
     if not public_keys:
         return False
 
-    import http.client
+    # The signature covers the ``content-digest`` header rather than the raw body,
+    # so verify the digest independently — otherwise a captured signature could be
+    # replayed against a tampered body.
+    if not _content_digest_matches(headers, body):
+        logger.debug("Signature verification failed: Content-Digest does not bind the body")
+        return False
 
     class _FakeRequest:
         """Minimal request object accepted by HTTPMessageVerifier."""

--- a/src/flight_blender/services/weather_service.py
+++ b/src/flight_blender/services/weather_service.py
@@ -1,6 +1,13 @@
 """
-Weather service — thin wrapper around the Open-Meteo (or similar) forecast API.
+Weather service — thin async wrapper around the Open-Meteo forecast API.
+
+Mirrors the Django ``services.weather_service.WeatherService``: same upstream
+params (including ``time``), the same ``WEATHER_TOPICS``, ``forecast_days``, a
+30s request timeout, and a non-200 -> error contract. The full upstream JSON
+object is returned unchanged.
 """
+
+import time as _time
 
 import httpx
 
@@ -12,21 +19,32 @@ WEATHER_TOPICS = [
     "windgusts_10m",
 ]
 
+UPSTREAM_TIMEOUT_SECONDS = 30
+
 
 class WeatherService:
     def __init__(self, base_url: str) -> None:
         self.base_url = base_url
 
-    async def get_weather(self, longitude: float, latitude: float, timezone: str) -> dict:
+    async def get_weather(
+        self,
+        longitude: float,
+        latitude: float,
+        timezone: str = "UTC",
+        time: int | float | str | None = None,
+    ) -> dict:
+        if time is None:
+            time = _time.time()
         params = {
             "longitude": longitude,
             "latitude": latitude,
+            "time": time,
             "timezone": timezone,
             "forecast_days": "1",
             "hourly": ",".join(WEATHER_TOPICS),
         }
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.get(self.base_url, params=params)
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(self.base_url, params=params, timeout=UPSTREAM_TIMEOUT_SECONDS)
         if resp.status_code != 200:
             raise ValueError(f"Error fetching weather data: {resp.text}")
         return resp.json()

--- a/src/flight_blender/tasks/__init__.py
+++ b/src/flight_blender/tasks/__init__.py
@@ -1,5 +1,6 @@
 """Celery tasks package."""
 
+from flight_blender.tasks import notification
 from flight_blender.tasks.celery_app import celery_app
 
-__all__ = ["celery_app"]
+__all__ = ["celery_app", "notification"]

--- a/src/flight_blender/tasks/celery_app.py
+++ b/src/flight_blender/tasks/celery_app.py
@@ -35,5 +35,9 @@ celery_app.conf.update(
             "task": "cleanup_old_heartbeat_events",
             "schedule": 3600.0,  # Every hour
         },
+        "periodic-conformance-check": {
+            "task": "check_all_flight_conformance",
+            "schedule": 30.0,  # Every 30 seconds
+        },
     },
 )

--- a/src/flight_blender/tasks/conformance.py
+++ b/src/flight_blender/tasks/conformance.py
@@ -1,50 +1,206 @@
 """
 Celery tasks for conformance monitoring.
+
+These tasks load the persisted flight declaration, geofences and live
+telemetry, then delegate the actual C2-C11 decision logic to the pure
+conformance engine in :mod:`flight_blender.services.conformance_engine`.
 """
 
-from loguru import logger
+from __future__ import annotations
 
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+
+from loguru import logger
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from flight_blender.common.enums import ACTIVE_OPERATIONAL_STATES
+from flight_blender.common.redis_stream_operations import read_latest_observation
+from flight_blender.config import get_settings
+from flight_blender.models.conformance import ConformanceRecord
+from flight_blender.models.flight_declaration import FlightDeclaration
+from flight_blender.models.geo_fence import GeoFence
+from flight_blender.services.conformance_engine import (
+    CONFORMANCE_CHECK_LABELS,
+    ConformanceCheck,
+    GeoFencePolygon,
+    OperationalIntentSnapshot,
+    TelemetryObservation,
+    VolumeBound,
+    check_operation_conformant_via_telemetry,
+    check_operational_intent_reference_conformance,
+)
 from flight_blender.tasks.celery_app import celery_app
+
+
+def _sync_engine():
+    settings = get_settings()
+    sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
+    return create_engine(sync_url)
+
+
+def _ussp_network_enabled() -> bool:
+    return bool(int(os.environ.get("USSP_NETWORK_ENABLED", 0)))
+
+
+def _record_from_result(
+    declaration_id: uuid.UUID,
+    result: ConformanceCheck,
+    event_type: str,
+) -> ConformanceRecord:
+    """Map an engine result onto a persisted ``ConformanceRecord``."""
+    is_conforming = result is ConformanceCheck.CONFORMANT
+    label = CONFORMANCE_CHECK_LABELS.get(result, "Unknown")
+    if is_conforming:
+        description = "Conformance check passed"
+    else:
+        description = f"Conformance check failed: {result.name} ({label})"
+    return ConformanceRecord(
+        flight_declaration_id=declaration_id,
+        conformance_state=1 if is_conforming else 0,
+        description=description,
+        event_type=event_type,
+        geofence_breach=result is ConformanceCheck.C8,
+        resolved=is_conforming,
+    )
+
+
+def _volumes_from_operational_intent(operational_intent_raw: str) -> list[VolumeBound]:
+    """Parse the declaration's operational_intent JSON into engine VolumeBounds.
+
+    Faithful to the Django ``cast_to_volume4d`` shape:
+    ``volume["volume"]["outline_polygon"]["vertices"]`` (lng/lat),
+    ``volume["volume"]["altitude_lower"|"altitude_upper"]["value"]``.
+    """
+    if not operational_intent_raw:
+        return []
+    try:
+        details = json.loads(operational_intent_raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+    bounds: list[VolumeBound] = []
+    for vol in details.get("volumes", []) or []:
+        volume = vol.get("volume", {})
+        outline = volume.get("outline_polygon") or {}
+        vertices = [(float(v["lng"]), float(v["lat"])) for v in outline.get("vertices", [])]
+        if len(vertices) < 3:
+            continue
+        altitude_lower = float((volume.get("altitude_lower") or {}).get("value", 0.0))
+        altitude_upper = float((volume.get("altitude_upper") or {}).get("value", 0.0))
+        bounds.append(
+            VolumeBound(
+                vertices=vertices,
+                altitude_lower=altitude_lower,
+                altitude_upper=altitude_upper,
+            )
+        )
+    return bounds
+
+
+def _rings_from_geometry(geometry: dict) -> list[list[tuple[float, float]]]:
+    """Extract outer-ring (lng, lat) vertex lists from a GeoJSON geometry."""
+    gtype = geometry.get("type")
+    coordinates = geometry.get("coordinates", [])
+    if gtype == "Polygon" and coordinates:
+        return [[(c[0], c[1]) for c in coordinates[0]]]
+    if gtype == "MultiPolygon":
+        return [[(c[0], c[1]) for c in polygon[0]] for polygon in coordinates if polygon]
+    return []
+
+
+def _geofences_from_records(geofences) -> list[GeoFencePolygon]:
+    """Convert GeoFence rows (GeoJSON) into engine GeoFencePolygon objects."""
+    polygons: list[GeoFencePolygon] = []
+    for geofence in geofences:
+        raw = getattr(geofence, "raw_geo_fence", None)
+        if not raw:
+            continue
+        try:
+            geojson = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        for feature in geojson.get("features", []):
+            for ring in _rings_from_geometry(feature.get("geometry", {})):
+                polygons.append(GeoFencePolygon(vertices=ring))
+    return polygons
+
+
+def _parse_telemetry(observation: dict) -> TelemetryObservation | None:
+    """Build a :class:`TelemetryObservation` from a Redis-stream observation dict.
+
+    The FastAPI flight-feed stream stores ``lat_dd`` / ``lon_dd`` (decimal
+    degrees), ``altitude_mm`` (millimetres) and ``icao_address``. Returns
+    ``None`` when the required position fields are missing.
+    """
+    try:
+        lat = float(observation["lat_dd"])
+        lng = float(observation["lon_dd"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    try:
+        altitude_mm = float(observation.get("altitude_mm", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        altitude_mm = 0.0
+    return TelemetryObservation(
+        aircraft_id=str(observation.get("icao_address", "")),
+        lat=lat,
+        lng=lng,
+        # stream stores millimetres; the engine works in metres WGS84.
+        altitude_m_wgs_84=altitude_mm / 1000.0,
+    )
+
+
+@celery_app.task(name="check_all_flight_conformance")
+def check_all_flight_conformance():
+    """Periodic dispatcher: fan out a conformance check to every active operation.
+
+    This is the FastAPI replacement for the dropped Django ``TaskScheduler``;
+    it is invoked on a fixed Celery-beat cadence and enqueues a per-declaration
+    :func:`check_flight_conformance` for each operation in an active state
+    (Activated / Nonconforming / Contingent).
+    """
+    active_states = [int(s) for s in ACTIVE_OPERATIONAL_STATES]
+    engine = _sync_engine()
+    with Session(engine) as session:
+        declarations = session.execute(select(FlightDeclaration).where(FlightDeclaration.state.in_(active_states))).scalars().all()
+        for decl in declarations:
+            check_flight_conformance.delay(str(decl.id))
+    logger.info("Dispatched conformance checks for active operations")
 
 
 @celery_app.task(name="check_flight_conformance", bind=True, max_retries=2)
 def check_flight_conformance(self, flight_declaration_id: str):
-    """
-    Verify that a flight conforms to its operational intent and declared geofences.
-    Creates a ConformanceRecord with the result.
+    """Telemetry-independent conformance (C9-C11): liveness and state checks.
+
+    Creates a ``ConformanceRecord`` capturing whether the operation's
+    operational-intent reference is conformant.
     """
     try:
-        import uuid
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import Session
-        from flight_blender.config import get_settings
-        from flight_blender.models.flight_declaration import FlightDeclaration
-        from flight_blender.models.conformance import ConformanceRecord
-
-        settings = get_settings()
-        sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-        engine = create_engine(sync_url)
-
+        engine = _sync_engine()
         with Session(engine) as session:
             decl = session.get(FlightDeclaration, uuid.UUID(flight_declaration_id))
             if not decl:
                 logger.error("Declaration %s not found for conformance check", flight_declaration_id)
                 return
 
-            # Simplified conformance check: declaration is conforming if it is in Activated state
-            is_conforming = decl.state == 2
-            record = ConformanceRecord(
-                flight_declaration_id=decl.id,
-                conformance_state=1 if is_conforming else 0,
-                description="Automated conformance check",
-                event_type="scheduled_check",
-                geofence_breach=False,
-                resolved=is_conforming,
+            result = check_operational_intent_reference_conformance(
+                state=decl.state,
+                latest_telemetry_datetime=decl.latest_telemetry_datetime,
+                operational_intent_reference_exists=True,
+                ussp_network_enabled=_ussp_network_enabled(),
             )
+            record = _record_from_result(decl.id, result, event_type="scheduled_check")
             session.add(record)
             session.commit()
-            logger.info("Conformance check for %s: %s", flight_declaration_id, "conforming" if is_conforming else "non-conforming")
-
+            logger.info(
+                "Conformance check for %s: %s",
+                flight_declaration_id,
+                "conforming" if result is ConformanceCheck.CONFORMANT else result.name,
+            )
     except Exception as exc:
         logger.error("Conformance check error: %s", exc)
         raise self.retry(exc=exc, countdown=30)
@@ -52,31 +208,52 @@ def check_flight_conformance(self, flight_declaration_id: str):
 
 @celery_app.task(name="check_operation_telemetry_conformance", bind=True, max_retries=2)
 def check_operation_telemetry_conformance(self, flight_declaration_id: str):
-    """
-    Check the latest telemetry position against the declared operational intent bounds.
-    """
+    """Telemetry-driven conformance (C2-C8) for the latest observation."""
     try:
-        import uuid
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import Session
-        from flight_blender.config import get_settings
-        from flight_blender.models.flight_declaration import FlightDeclaration
-        from flight_blender.common.redis_stream_operations import read_latest_observation
-
-        settings = get_settings()
-        sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-        engine = create_engine(sync_url)
-
         latest = read_latest_observation(session_id=flight_declaration_id)
         if not latest:
             logger.debug("No telemetry for %s", flight_declaration_id)
             return
 
+        engine = _sync_engine()
         with Session(engine) as session:
             decl = session.get(FlightDeclaration, uuid.UUID(flight_declaration_id))
-            if decl:
-                check_flight_conformance.delay(flight_declaration_id)
+            if not decl:
+                logger.error("Declaration %s not found for telemetry conformance check", flight_declaration_id)
+                return
 
+            telemetry = _parse_telemetry(latest)
+            if telemetry is None:
+                logger.debug("Telemetry for %s missing position fields", flight_declaration_id)
+                return
+
+            now = datetime.now(timezone.utc)
+            active_geofences = session.execute(select(GeoFence).where(GeoFence.start_datetime <= now, GeoFence.end_datetime >= now)).scalars().all()
+
+            snapshot = OperationalIntentSnapshot(
+                aircraft_id=decl.aircraft_id,
+                state=decl.state,
+                start_datetime=decl.start_datetime,
+                end_datetime=decl.end_datetime,
+                volumes=_volumes_from_operational_intent(decl.operational_intent),
+                operational_intent_reference_exists=True,
+            )
+
+            result = check_operation_conformant_via_telemetry(
+                snapshot=snapshot,
+                telemetry=telemetry,
+                geofences=_geofences_from_records(active_geofences),
+                now=now,
+                ussp_network_enabled=_ussp_network_enabled(),
+            )
+            record = _record_from_result(decl.id, result, event_type="telemetry_check")
+            session.add(record)
+            session.commit()
+            logger.info(
+                "Telemetry conformance check for %s: %s",
+                flight_declaration_id,
+                "conforming" if result is ConformanceCheck.CONFORMANT else result.name,
+            )
     except Exception as exc:
         logger.error("Telemetry conformance check error: %s", exc)
         raise self.retry(exc=exc, countdown=30)

--- a/src/flight_blender/tasks/conformance.py
+++ b/src/flight_blender/tasks/conformance.py
@@ -37,9 +37,9 @@ from flight_blender.tasks.celery_app import celery_app
 
 
 def _sync_engine():
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-    return create_engine(sync_url)
+    from flight_blender.common.sync_engine import get_sync_engine
+
+    return get_sync_engine(get_settings().database_url)
 
 
 def _ussp_network_enabled() -> bool:

--- a/src/flight_blender/tasks/flight_declaration.py
+++ b/src/flight_blender/tasks/flight_declaration.py
@@ -15,6 +15,7 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
     Validates start/end times, submits the operational intent, and updates the
     declaration state based on the DSS response.
     """
+    import json
     import uuid
     from datetime import datetime, timezone
 
@@ -24,6 +25,7 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
     from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
     from flight_blender.config import get_settings
     from flight_blender.models.flight_declaration import FlightDeclaration, FlightOperationalIntentReference
+    from flight_blender.services.peer_uss_client import build_operational_intent_reference_payload
 
     settings = get_settings()
     sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
@@ -58,13 +60,24 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
             import requests
 
             opint_id = str(uuid.uuid4())
-            body = {
-                "extents": [],
-                "key": [],
-                "state": "Accepted",
-                "uss_base_url": settings.dss_self_audience,
-                "new_subscription": None,
-            }
+
+            # Build non-empty extents from the operation's stored volumes (the
+            # operational_intent JSON holds the list of Volume4Ds for op-intent
+            # ingests). The airspace ``key`` requires a live DSS area query of
+            # overlapping op-intent references — that round-trip is a documented
+            # follow-up, so existing_references stays [] (key remains []).
+            try:
+                stored = json.loads(decl.operational_intent) if decl.operational_intent else []
+            except (json.JSONDecodeError, TypeError):
+                stored = []
+            volumes = stored if isinstance(stored, list) else []
+
+            body = build_operational_intent_reference_payload(
+                volumes=volumes,
+                state="Accepted",
+                existing_references=[],
+                uss_base_url=settings.dss_self_audience,
+            )
 
             resp = requests.put(
                 f"{dss_base_url}/dss/v1/operational_intent_references/{opint_id}",

--- a/src/flight_blender/tasks/flight_declaration.py
+++ b/src/flight_blender/tasks/flight_declaration.py
@@ -19,7 +19,6 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
     import uuid
     from datetime import datetime, timezone
 
-    from sqlalchemy import create_engine
     from sqlalchemy.orm import Session
 
     from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
@@ -27,9 +26,10 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
     from flight_blender.models.flight_declaration import FlightDeclaration, FlightOperationalIntentReference
     from flight_blender.services.peer_uss_client import build_operational_intent_reference_payload
 
+    from flight_blender.common.sync_engine import get_sync_engine
+
     settings = get_settings()
-    sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-    engine = create_engine(sync_url)
+    engine = get_sync_engine(settings.database_url)
 
     with Session(engine) as session:
         decl = session.get(FlightDeclaration, uuid.UUID(flight_declaration_id))
@@ -54,7 +54,7 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
             credentials = creds_getter.get_cached_credentials(audience=audience, token_type="scd")  # nosec B106
             token = credentials.get("access_token", "")
 
-            dss_base_url = settings.__dict__.get("dss_base_url", "http://host.docker.internal:8082")
+            dss_base_url = settings.dss_base_url
             headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
             import requests

--- a/src/flight_blender/tasks/flight_declaration.py
+++ b/src/flight_blender/tasks/flight_declaration.py
@@ -15,13 +15,15 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
     Validates start/end times, submits the operational intent, and updates the
     declaration state based on the DSS response.
     """
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import Session
-    from flight_blender.config import get_settings
-    from flight_blender.models.flight_declaration import FlightDeclaration, FlightOperationalIntentReference
-    from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
     import uuid
     from datetime import datetime, timezone
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
+    from flight_blender.config import get_settings
+    from flight_blender.models.flight_declaration import FlightDeclaration, FlightOperationalIntentReference
 
     settings = get_settings()
     sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
@@ -102,6 +104,7 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
 
 def _add_tracking(session, decl, notes: str) -> None:
     import json
+
     from flight_blender.models.flight_declaration import FlightOperationTracking
 
     tracking = FlightOperationTracking(
@@ -117,13 +120,23 @@ def send_operational_update_message(self, flight_declaration_id: str, message_te
     """
     Dispatch an AMQP / notification message about a flight declaration state change.
     """
-    import pika
     import json
     import os
 
+    import pika
+
     amqp_url = os.getenv("AMQP_URL", "")
     if not amqp_url:
-        logger.debug("No AMQP_URL configured; skipping notification for %s", flight_declaration_id)
+        # P2: without a broker the notification must not be silently dropped.
+        # Persist it locally (mirroring the Django consumer's row creation) and
+        # warn that the AMQP publish was skipped.
+        logger.warning("No AMQP_URL configured; persisting notification locally for %s", flight_declaration_id)
+        from flight_blender.tasks import notification as notification_tasks
+
+        notification_tasks._persist_operator_rid_notification_sync(
+            message=message_text,
+            session_id=flight_declaration_id,
+        )
         return
 
     try:

--- a/src/flight_blender/tasks/flight_declaration.py
+++ b/src/flight_blender/tasks/flight_declaration.py
@@ -21,7 +21,7 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
 
     from sqlalchemy.orm import Session
 
-    from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
+    from flight_blender.auth.dss import get_dss_auth_header
     from flight_blender.config import get_settings
     from flight_blender.models.flight_declaration import FlightDeclaration, FlightOperationalIntentReference
     from flight_blender.services.peer_uss_client import build_operational_intent_reference_payload
@@ -49,13 +49,8 @@ def submit_flight_declaration_to_dss_async(self, flight_declaration_id: str):
         logger.info("Submitting declaration %s to DSS", flight_declaration_id)
 
         try:
-            creds_getter = AuthorityCredentialsGetter()
-            audience = settings.dss_self_audience
-            credentials = creds_getter.get_cached_credentials(audience=audience, token_type="scd")  # nosec B106
-            token = credentials.get("access_token", "")
-
             dss_base_url = settings.dss_base_url
-            headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+            headers = get_dss_auth_header(audience=settings.dss_self_audience, token_type="scd")
 
             import requests
 

--- a/src/flight_blender/tasks/flight_feed.py
+++ b/src/flight_blender/tasks/flight_feed.py
@@ -3,12 +3,28 @@ Celery tasks for flight feed / air traffic observation processing.
 """
 
 import json
+from typing import Any
 
 import requests
 from loguru import logger
 
 from flight_blender.common.redis_stream_operations import add_air_traffic_data
+from flight_blender.models.flight_feed import FlightObservation
 from flight_blender.tasks.celery_app import celery_app
+
+
+def _build_observation(raw: dict[str, Any]) -> FlightObservation:
+    """Construct a ``FlightObservation`` from an observation dict."""
+    return FlightObservation(
+        latitude_dd=float(raw.get("lat_dd", raw.get("latitude_dd", 0))),
+        longitude_dd=float(raw.get("lon_dd", raw.get("longitude_dd", 0))),
+        altitude_mm=float(raw.get("altitude_mm", 0)),
+        traffic_source=int(raw.get("traffic_source", 12)),
+        source_type=int(raw.get("source_type", 0)),
+        icao_address=str(raw.get("icao_address", "")),
+        metadata_=json.dumps(raw["metadata"]) if isinstance(raw.get("metadata"), dict) else str(raw.get("metadata", "")),
+        session_id=raw.get("session_id"),
+    )
 
 
 def _parse_viewport(view_port: str) -> dict:
@@ -51,23 +67,11 @@ def write_incoming_air_traffic_data(self, observation: dict):
         from sqlalchemy.orm import Session
         from flight_blender.common.sync_engine import get_sync_engine
         from flight_blender.config import get_settings
-        from flight_blender.models.flight_feed import FlightObservation
 
         engine = get_sync_engine(get_settings().database_url)
 
         with Session(engine) as session:
-            obs = FlightObservation(
-                latitude_dd=float(observation.get("lat_dd", observation.get("latitude_dd", 0))),
-                longitude_dd=float(observation.get("lon_dd", observation.get("longitude_dd", 0))),
-                altitude_mm=float(observation.get("altitude_mm", 0)),
-                traffic_source=int(observation.get("traffic_source", 12)),
-                source_type=int(observation.get("source_type", 0)),
-                icao_address=str(observation.get("icao_address", "")),
-                metadata_=json.dumps(observation.get("metadata", {}))
-                if isinstance(observation.get("metadata"), dict)
-                else str(observation.get("metadata", "")),
-                session_id=observation.get("session_id"),
-            )
+            obs = _build_observation(observation)
             session.add(obs)
             session.commit()
 
@@ -87,25 +91,11 @@ def bulk_write_incoming_air_traffic_data(self, observations: list[dict]):
         from sqlalchemy.orm import Session
         from flight_blender.common.sync_engine import get_sync_engine
         from flight_blender.config import get_settings
-        from flight_blender.models.flight_feed import FlightObservation
 
         engine = get_sync_engine(get_settings().database_url)
 
         with Session(engine) as session:
-            obs_objects = []
-            for obs in observations:
-                obs_objects.append(
-                    FlightObservation(
-                        latitude_dd=float(obs.get("lat_dd", obs.get("latitude_dd", 0))),
-                        longitude_dd=float(obs.get("lon_dd", obs.get("longitude_dd", 0))),
-                        altitude_mm=float(obs.get("altitude_mm", 0)),
-                        traffic_source=int(obs.get("traffic_source", 12)),
-                        source_type=int(obs.get("source_type", 0)),
-                        icao_address=str(obs.get("icao_address", "")),
-                        metadata_=json.dumps(obs.get("metadata", {})) if isinstance(obs.get("metadata"), dict) else str(obs.get("metadata", "")),
-                        session_id=obs.get("session_id"),
-                    )
-                )
+            obs_objects = [_build_observation(obs) for obs in observations]
             session.add_all(obs_objects)
             session.commit()
 

--- a/src/flight_blender/tasks/flight_feed.py
+++ b/src/flight_blender/tasks/flight_feed.py
@@ -48,15 +48,12 @@ def write_incoming_air_traffic_data(self, observation: dict):
     This task uses a synchronous SQLAlchemy session because Celery workers are sync.
     """
     try:
-        from sqlalchemy import create_engine
         from sqlalchemy.orm import Session
+        from flight_blender.common.sync_engine import get_sync_engine
         from flight_blender.config import get_settings
         from flight_blender.models.flight_feed import FlightObservation
 
-        settings = get_settings()
-        # Convert async URL to sync
-        sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-        engine = create_engine(sync_url)
+        engine = get_sync_engine(get_settings().database_url)
 
         with Session(engine) as session:
             obs = FlightObservation(
@@ -87,14 +84,12 @@ def bulk_write_incoming_air_traffic_data(self, observations: list[dict]):
     Persist a batch of air traffic observations and push each to the Redis stream.
     """
     try:
-        from sqlalchemy import create_engine
         from sqlalchemy.orm import Session
+        from flight_blender.common.sync_engine import get_sync_engine
         from flight_blender.config import get_settings
         from flight_blender.models.flight_feed import FlightObservation
 
-        settings = get_settings()
-        sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-        engine = create_engine(sync_url)
+        engine = get_sync_engine(get_settings().database_url)
 
         with Session(engine) as session:
             obs_objects = []

--- a/src/flight_blender/tasks/geo_fence.py
+++ b/src/flight_blender/tasks/geo_fence.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 import requests
 from loguru import logger
 
+from flight_blender.common.geometry import compute_bounds
 from flight_blender.tasks.celery_app import celery_app
 
 # ── GeoZone source status store ──────────────────────────────────────────────
@@ -35,18 +36,9 @@ _in_memory_status: dict[str, dict] = {}
 def _get_redis():
     """Return a connected Redis client, or ``None`` if Redis is unavailable."""
     try:
-        import redis
+        from flight_blender.common.redis_client import get_redis
 
-        from flight_blender.config import get_settings
-
-        settings = get_settings()
-        client = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            password=settings.redis_password,
-            db=0,
-            socket_connect_timeout=1,
-        )
+        client = get_redis()
         client.ping()
         return client
     except Exception:  # noqa: BLE001 - any failure means "no Redis"; degrade
@@ -160,26 +152,10 @@ def feature_to_coordinates(feature: dict) -> list[list[float]]:
     return coords
 
 
-def compute_bounds(coordinates: list[list[float]]) -> str:
-    """Return ``"minx,miny,maxx,maxy"`` (7 dp) for a set of ``[lon, lat]`` pairs."""
-    if not coordinates:
-        return ""
-    lons = [c[0] for c in coordinates]
-    lats = [c[1] for c in coordinates]
-    bnd = (min(lons), min(lats), max(lons), max(lats))
-    return ",".join(f"{x:.7f}" for x in bnd)
-
-
 def _parse_dt(value, fallback: datetime) -> datetime:
-    if not value:
-        return fallback
-    try:
-        dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except (TypeError, ValueError):
-        return fallback
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt
+    from flight_blender.common.datetime_utils import parse_iso_utc
+
+    return parse_iso_utc(value, fallback=fallback) or fallback
 
 
 def validate_geo_zone(geo_zone) -> bool:

--- a/src/flight_blender/tasks/geo_fence.py
+++ b/src/flight_blender/tasks/geo_fence.py
@@ -269,9 +269,9 @@ def write_geo_zone(self, geozone_data, source_url: str = ""):
     try:
         # Import inside the task so tests can patch ``sqlalchemy.create_engine`` /
         # ``sqlalchemy.orm.Session`` (matches the other Celery tasks).
-        from sqlalchemy import create_engine
         from sqlalchemy.orm import Session
 
+        from flight_blender.common.sync_engine import get_sync_engine
         from flight_blender.config import get_settings
         from flight_blender.models.geo_fence import GeoFence
 
@@ -283,9 +283,7 @@ def write_geo_zone(self, geozone_data, source_url: str = ""):
             logger.warning("No GeoZone features found in payload from {}", source_url)
             return
 
-        settings = get_settings()
-        sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-        engine = create_engine(sync_url)
+        engine = get_sync_engine(get_settings().database_url)
         with Session(engine) as session:
             for fields in parsed:
                 session.add(GeoFence(**fields))

--- a/src/flight_blender/tasks/geo_fence.py
+++ b/src/flight_blender/tasks/geo_fence.py
@@ -1,69 +1,296 @@
 """
-Celery tasks for geo fence / geozone operations.
+Celery tasks and pure-Python GeoZone parsing for geo fence / geozone operations.
+
+The parsing pipeline ports the Django ``geo_fence_operations`` behaviour:
+
+* ED-269 ``UASZoneList`` features are read with the correct ``upperLimit`` /
+  ``lowerLimit`` field names.
+* ``Circle`` horizontal projections are buffered into a polygon ring (pure
+  Python, no shapely dependency).
+* Real bounding boxes are computed and stored as a comma-separated
+  ``"minx,miny,maxx,maxy"`` string (matching the Django ``unary_union(...).bounds``
+  formatting), and the raw GeoZone document is persisted on ``geozone``.
+* Each persisted ``GeoFence`` is flagged ``is_test_dataset=True`` because the
+  geozone ingest path feeds the InterUSS geo-awareness test harness.
 """
 
 import json
+import math
+from datetime import datetime, timezone
 
 import requests
 from loguru import logger
 
 from flight_blender.tasks.celery_app import celery_app
 
+# ── GeoZone source status store ──────────────────────────────────────────────
+# The InterUSS qualifier PUTs a geospatial data source, then polls its status.
+# We mirror the Django Redis bookkeeping but degrade gracefully to an in-process
+# dict when Redis is unavailable (e.g. tests, local dev without a broker).
+
+_STATUS_KEY_PREFIX = "geoawareness_test."
+_in_memory_status: dict[str, dict] = {}
+
+
+def _get_redis():
+    """Return a connected Redis client, or ``None`` if Redis is unavailable."""
+    try:
+        import redis
+
+        from flight_blender.config import get_settings
+
+        settings = get_settings()
+        client = redis.Redis(
+            host=settings.redis_host,
+            port=settings.redis_port,
+            password=settings.redis_password,
+            db=0,
+            socket_connect_timeout=1,
+        )
+        client.ping()
+        return client
+    except Exception:  # noqa: BLE001 - any failure means "no Redis"; degrade
+        return None
+
+
+def set_geozone_source_status(geozone_source_id: str, status: dict, ttl: int = 3000) -> None:
+    """Persist the import status for a geozone source id."""
+    key = _STATUS_KEY_PREFIX + str(geozone_source_id)
+    payload = json.dumps(status)
+    client = _get_redis()
+    if client is not None:
+        try:
+            client.set(key, payload)
+            client.expire(name=key, time=ttl)
+            return
+        except Exception:  # noqa: BLE001 - fall back to memory
+            pass
+    _in_memory_status[key] = status
+
+
+def get_geozone_source_status(geozone_source_id: str) -> dict | None:
+    """Return the stored import status for a geozone source id, or ``None``."""
+    key = _STATUS_KEY_PREFIX + str(geozone_source_id)
+    client = _get_redis()
+    if client is not None:
+        try:
+            if client.exists(key):
+                return json.loads(client.get(key))
+            return None
+        except Exception:  # noqa: BLE001 - fall back to memory
+            pass
+    return _in_memory_status.get(key)
+
+
+def delete_geozone_source_status(geozone_source_id: str) -> bool:
+    """Delete the stored status. Returns True if a record existed."""
+    key = _STATUS_KEY_PREFIX + str(geozone_source_id)
+    client = _get_redis()
+    if client is not None:
+        try:
+            if client.exists(key):
+                client.delete(key)
+                return True
+            return False
+        except Exception:  # noqa: BLE001 - fall back to memory
+            pass
+    return _in_memory_status.pop(key, None) is not None
+
+
+# ── Pure-Python geometry helpers ─────────────────────────────────────────────
+
+_EARTH_RADIUS_M = 6378137.0
+
+
+def geodesic_circle_to_ring(center_lon: float, center_lat: float, radius_m: float, segments: int = 32) -> list[list[float]]:
+    """Approximate a geodesic circle as a closed polygon ring of ``[lon, lat]`` pairs.
+
+    Pure-Python replacement for the Django ``geodesic_point_buffer`` (shapely +
+    pyproj). Accurate enough for bounding-box computation and point-in-polygon
+    membership at the small radii used by geo-awareness zones.
+    """
+    ring: list[list[float]] = []
+    lat_rad = math.radians(center_lat)
+    d_lat = (radius_m / _EARTH_RADIUS_M) * (180.0 / math.pi)
+    cos_lat = math.cos(lat_rad) or 1e-9
+    d_lon = (radius_m / (_EARTH_RADIUS_M * cos_lat)) * (180.0 / math.pi)
+    for i in range(segments):
+        theta = 2.0 * math.pi * (i / segments)
+        ring.append([center_lon + d_lon * math.cos(theta), center_lat + d_lat * math.sin(theta)])
+    ring.append(ring[0])
+    return ring
+
+
+def _flatten_coordinates(coords) -> list[list[float]]:
+    """Recursively flatten arbitrarily nested coordinate arrays to ``[lon, lat]`` pairs."""
+    flat: list[list[float]] = []
+    if not isinstance(coords, (list, tuple)):
+        return flat
+    if len(coords) >= 2 and all(isinstance(c, (int, float)) for c in coords[:2]):
+        flat.append([float(coords[0]), float(coords[1])])
+        return flat
+    for item in coords:
+        flat.extend(_flatten_coordinates(item))
+    return flat
+
+
+def feature_to_coordinates(feature: dict) -> list[list[float]]:
+    """Extract ``[lon, lat]`` pairs from an ED-269 UASZone feature.
+
+    Supports both ``geometry: [{horizontalProjection: {...}}]`` (ED-269) and a
+    plain GeoJSON ``geometry`` object. ``Circle`` projections are buffered into a
+    polygon ring.
+    """
+    geometries = feature.get("geometry")
+    coords: list[list[float]] = []
+    if isinstance(geometries, dict):
+        geometries = [{"horizontalProjection": geometries}]
+    if not isinstance(geometries, list):
+        return coords
+    for geom in geometries:
+        proj = geom.get("horizontalProjection", geom) if isinstance(geom, dict) else {}
+        gtype = proj.get("type")
+        if gtype == "Circle":
+            center = proj.get("center", [])
+            radius = float(proj.get("radius", 0) or 0)
+            if len(center) >= 2:
+                coords.extend(geodesic_circle_to_ring(float(center[0]), float(center[1]), radius))
+        else:
+            coords.extend(_flatten_coordinates(proj.get("coordinates", [])))
+    return coords
+
+
+def compute_bounds(coordinates: list[list[float]]) -> str:
+    """Return ``"minx,miny,maxx,maxy"`` (7 dp) for a set of ``[lon, lat]`` pairs."""
+    if not coordinates:
+        return ""
+    lons = [c[0] for c in coordinates]
+    lats = [c[1] for c in coordinates]
+    bnd = (min(lons), min(lats), max(lons), max(lats))
+    return ",".join(f"{x:.7f}" for x in bnd)
+
+
+def _parse_dt(value, fallback: datetime) -> datetime:
+    if not value:
+        return fallback
+    try:
+        dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return fallback
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def validate_geo_zone(geo_zone) -> bool:
+    """Validate a GeoZone payload (Django ``common.validate_geo_zone`` parity).
+
+    Accepts a dict or a JSON string. A valid GeoZone is a dict carrying a
+    non-empty feature list (``UASZoneList`` or ``features``) where each feature is
+    a dict that describes itself in some way: a geometry, an identifier/name, or a
+    zone authority. Empty or non-dict payloads are rejected.
+    """
+    if isinstance(geo_zone, str):
+        try:
+            geo_zone = json.loads(geo_zone)
+        except (TypeError, ValueError):
+            return False
+    if not isinstance(geo_zone, dict):
+        return False
+    features = _geo_zone_features(geo_zone)
+    if not features or not isinstance(features, list):
+        return False
+    descriptors = ("geometry", "name", "identifier", "title", "zoneAuthority", "applicability")
+    return all(isinstance(f, dict) and any(f.get(k) for k in descriptors) for f in features)
+
+
+def _geo_zone_features(geo_zone: dict) -> list:
+    """Return the feature list under any of the accepted GeoZone keys."""
+    return geo_zone.get("UASZoneList") or geo_zone.get("features") or geo_zone.get("GeoZones") or []
+
+
+def parse_geo_zone_features(geo_zone: dict) -> list[dict]:
+    """Parse an ED-269 GeoZone document into per-feature persistence dicts."""
+    features = _geo_zone_features(geo_zone)
+    now = datetime.now(timezone.utc)
+    parsed: list[dict] = []
+    for feature in features:
+        if not isinstance(feature, dict):
+            continue
+        coordinates = feature_to_coordinates(feature)
+        bounds = compute_bounds(coordinates)
+        applicability = feature.get("applicability") or {}
+        if isinstance(applicability, list):
+            applicability = applicability[0] if applicability else {}
+        start_dt = _parse_dt(applicability.get("startDateTime"), now)
+        end_dt = _parse_dt(applicability.get("endDateTime"), start_dt)
+        name = feature.get("name") or feature.get("identifier") or feature.get("title") or "Unknown"
+        parsed.append(
+            {
+                "geozone": json.dumps(feature),
+                "raw_geo_fence": json.dumps(geo_zone),
+                "upper_limit": float(feature.get("upperLimit", feature.get("upper_limit", feature.get("upper_limit_m", 120))) or 0),
+                "lower_limit": float(feature.get("lowerLimit", feature.get("lower_limit", feature.get("lower_limit_m", 0))) or 0),
+                "altitude_ref": 0,
+                "name": str(name)[:50],
+                "bounds": bounds,
+                "status": 1,
+                "is_test_dataset": True,
+                "start_datetime": start_dt,
+                "end_datetime": end_dt,
+            }
+        )
+    return parsed
+
+
+# ── Celery tasks ─────────────────────────────────────────────────────────────
+
 
 @celery_app.task(name="download_geozone_source", bind=True, max_retries=3)
-def download_geozone_source(self, url: str):
-    """Download a GeoZone source from a URL and queue it for parsing."""
+def download_geozone_source(self, geo_zone_url: str, geozone_source_id: str = ""):
+    """Download a GeoZone source from a URL, parse it, and record import status."""
     try:
-        resp = requests.get(url, timeout=60)
+        resp = requests.get(geo_zone_url, timeout=60)
         resp.raise_for_status()
         data = resp.json()
-        write_geo_zone.delay(data, source_url=url)
-    except Exception as exc:
-        logger.error("GeoZone download error from %s: %s", url, exc)
+        write_geo_zone.delay(data)
+        if geozone_source_id:
+            set_geozone_source_status(geozone_source_id, {"result": "Ready", "message": ""})
+    except Exception as exc:  # noqa: BLE001
+        logger.error("GeoZone download error from {}: {}", geo_zone_url, exc)
+        if geozone_source_id:
+            set_geozone_source_status(geozone_source_id, {"result": "Error", "message": str(exc)})
         raise self.retry(exc=exc, countdown=30)
 
 
 @celery_app.task(name="write_geo_zone", bind=True, max_retries=2)
-def write_geo_zone(self, geozone_data: dict, source_url: str = ""):
-    """
-    Parse an ED-269 GeoZone feature collection and persist GeoFence records.
-    """
+def write_geo_zone(self, geozone_data, source_url: str = ""):
+    """Parse an ED-269 GeoZone document and persist one GeoFence per feature."""
     try:
+        # Import inside the task so tests can patch ``sqlalchemy.create_engine`` /
+        # ``sqlalchemy.orm.Session`` (matches the other Celery tasks).
         from sqlalchemy import create_engine
         from sqlalchemy.orm import Session
+
         from flight_blender.config import get_settings
         from flight_blender.models.geo_fence import GeoFence
-        from datetime import datetime
+
+        if isinstance(geozone_data, str):
+            geozone_data = json.loads(geozone_data)
+
+        parsed = parse_geo_zone_features(geozone_data)
+        if not parsed:
+            logger.warning("No GeoZone features found in payload from {}", source_url)
+            return
 
         settings = get_settings()
         sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
         engine = create_engine(sync_url)
-
-        features = geozone_data.get("features", geozone_data.get("GeoZones", []))
-        if not features:
-            logger.warning("No GeoZone features found in payload from %s", source_url)
-            return
-
         with Session(engine) as session:
-            created_count = 0
-            for feature in features:
-                name = feature.get("name", feature.get("identifier", "Unknown"))
-                fence = GeoFence(
-                    geozone=json.dumps(feature),
-                    upper_limit=float(feature.get("upper_limit_m", 120)),
-                    lower_limit=float(feature.get("lower_limit_m", 0)),
-                    altitude_ref=0,
-                    name=str(name)[:50],
-                    bounds="",
-                    status=1,
-                    start_datetime=datetime.now(),
-                    end_datetime=datetime.now(),
-                )
-                session.add(fence)
-                created_count += 1
+            for fields in parsed:
+                session.add(GeoFence(**fields))
             session.commit()
-            logger.info("Created %d GeoFence records from GeoZone source", created_count)
-
-    except Exception as exc:
-        logger.error("GeoZone write error: %s", exc)
+            logger.info("Created {} GeoFence records from GeoZone source", len(parsed))
+    except Exception as exc:  # noqa: BLE001
+        logger.error("GeoZone write error: {}", exc)
         raise self.retry(exc=exc, countdown=10)

--- a/src/flight_blender/tasks/notification.py
+++ b/src/flight_blender/tasks/notification.py
@@ -1,0 +1,129 @@
+"""Operator-RID notification persistence and consumer (FastAPI port).
+
+Mirrors the Django ``notification_operations`` app:
+
+* ``OperatorRIDNotificationCreator`` (``notification_helper.py``) created an
+  ``OperatorRIDNotification`` row from a message + session id.
+* the ``operator_rid_notifications`` management command consumed messages from
+  the durable ``operization_events`` topic exchange and created those rows.
+
+In the FastAPI port the row-creation logic is a dependency-injected async
+function (``create_operator_rid_notification``) so it can be unit-tested against
+the test DB, while ``consume_operator_rid_notifications`` is an import-safe
+consumer entrypoint that becomes a no-op when ``AMQP_URL`` is not configured.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from flight_blender.database import AsyncSessionLocal
+from flight_blender.models.notification import OperatorRIDNotification
+
+logger = logging.getLogger(__name__)
+
+# Durable topic exchange used by the Django notification helper/consumer.
+NOTIFICATION_EXCHANGE = "operization_events"
+
+
+def _coerce_message(message: Any) -> str:
+    """Return a text representation of a notification message.
+
+    Messages delivered over AMQP arrive as JSON (a ``dict``); the persisted
+    model field is text, so dict/list payloads are serialised to JSON.
+    """
+    if isinstance(message, str):
+        return message
+    return json.dumps(message)
+
+
+async def create_operator_rid_notification(
+    *,
+    message: Any,
+    session_id: str | None,
+    db: AsyncSession,
+) -> OperatorRIDNotification:
+    """Persist an :class:`OperatorRIDNotification` row.
+
+    Faithful port of Django's ``OperatorRIDNotificationCreator.create_notification``:
+    stores ``message`` and ``session_id`` (``is_active`` defaults to ``True``).
+    """
+    notification = OperatorRIDNotification(
+        message=_coerce_message(message),
+        session_id=session_id,
+    )
+    db.add(notification)
+    await db.commit()
+    await db.refresh(notification)
+    return notification
+
+
+async def list_operator_rid_notifications(
+    *,
+    db: AsyncSession,
+    session_id: str | None = None,
+) -> list[OperatorRIDNotification]:
+    """Read persisted notifications (internal helper, optionally by session)."""
+    stmt = select(OperatorRIDNotification)
+    if session_id is not None:
+        stmt = stmt.where(OperatorRIDNotification.session_id == session_id)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _persist_operator_rid_notification_sync(*, message: Any, session_id: str | None) -> None:
+    """Synchronous wrapper used by Celery tasks to persist a notification.
+
+    Runs the async creator against a fresh session. Resilient by design: any
+    failure is logged rather than raised so callers (e.g. the publish task) never
+    crash on a best-effort local persist.
+    """
+
+    async def _runner() -> None:
+        async with AsyncSessionLocal() as session:
+            await create_operator_rid_notification(message=message, session_id=session_id, db=session)
+
+    try:
+        asyncio.run(_runner())
+    except Exception:  # pragma: no cover - best-effort local persistence
+        logger.exception("Failed to persist operator RID notification locally")
+
+
+def consume_operator_rid_notifications() -> None:
+    """Consume operator-RID notifications from AMQP and persist them.
+
+    Mirrors the Django ``operator_rid_notifications`` management command. This is
+    a long-running blocking consumer; it is import-safe and a no-op when
+    ``AMQP_URL`` is not configured so it can be imported in any environment.
+    """
+    amqp_connection_url = os.getenv("AMQP_URL")
+    if not amqp_connection_url:
+        logger.warning("AMQP_URL is not set; operator RID notification consumer is a no-op")
+        return
+
+    import pika  # imported lazily so the module stays import-safe without pika configured
+
+    connection = pika.BlockingConnection(pika.URLParameters(amqp_connection_url))
+    channel = connection.channel()
+    channel.exchange_declare(exchange=NOTIFICATION_EXCHANGE, exchange_type="topic", durable=True)
+    result = channel.queue_declare(queue="", exclusive=True)
+    queue_name = result.method.queue
+    channel.queue_bind(exchange=NOTIFICATION_EXCHANGE, queue=queue_name, routing_key="#")
+
+    def callback(ch, method, properties, body):  # noqa: ANN001 - pika callback signature
+        try:
+            message = json.loads(body)
+        except (ValueError, TypeError):
+            message = body.decode("utf-8") if isinstance(body, bytes) else str(body)
+        session_id = method.routing_key
+        _persist_operator_rid_notification_sync(message=message, session_id=session_id)
+
+    channel.basic_consume(queue=queue_name, on_message_callback=callback, auto_ack=True)
+    channel.start_consuming()

--- a/src/flight_blender/tasks/rid.py
+++ b/src/flight_blender/tasks/rid.py
@@ -13,22 +13,21 @@ def submit_dss_subscription(self, subscription_db_id: str, view: str, end_dateti
     try:
         import uuid
         import requests
-        from sqlalchemy import create_engine
         from sqlalchemy.orm import Session
+        from flight_blender.common.sync_engine import get_sync_engine
         from flight_blender.config import get_settings
         from flight_blender.models.rid import ISASubscription
         from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
 
         settings = get_settings()
-        sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-        engine = create_engine(sync_url)
+        engine = get_sync_engine(settings.database_url)
 
         creds_getter = AuthorityCredentialsGetter()
         credentials = creds_getter.get_cached_credentials(audience=settings.dss_self_audience, token_type="rid")  # nosec B106
         token = credentials.get("access_token", "")
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
-        dss_base_url = settings.__dict__.get("dss_base_url", "http://host.docker.internal:8082")
+        dss_base_url = settings.dss_base_url
         sub_id = str(uuid.uuid4())
         # Parse bounding box: lat_lo,lng_lo,lat_hi,lng_hi
         coords = [float(c) for c in view.split(",")]
@@ -77,14 +76,12 @@ def write_operator_rid_notification(self, session_id: str, message: str, flight_
     """Persist an operator RID notification."""
     try:
         import uuid
-        from sqlalchemy import create_engine
         from sqlalchemy.orm import Session
+        from flight_blender.common.sync_engine import get_sync_engine
         from flight_blender.config import get_settings
         from flight_blender.models.notification import OperatorRIDNotification
 
-        settings = get_settings()
-        sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-        engine = create_engine(sync_url)
+        engine = get_sync_engine(get_settings().database_url)
 
         with Session(engine) as session:
             notif = OperatorRIDNotification(

--- a/src/flight_blender/tasks/rid.py
+++ b/src/flight_blender/tasks/rid.py
@@ -14,18 +14,15 @@ def submit_dss_subscription(self, subscription_db_id: str, view: str, end_dateti
         import uuid
         import requests
         from sqlalchemy.orm import Session
+        from flight_blender.auth.dss import get_dss_auth_header
         from flight_blender.common.sync_engine import get_sync_engine
         from flight_blender.config import get_settings
         from flight_blender.models.rid import ISASubscription
-        from flight_blender.auth.dss_auth_helper import AuthorityCredentialsGetter
 
         settings = get_settings()
         engine = get_sync_engine(settings.database_url)
 
-        creds_getter = AuthorityCredentialsGetter()
-        credentials = creds_getter.get_cached_credentials(audience=settings.dss_self_audience, token_type="rid")  # nosec B106
-        token = credentials.get("access_token", "")
-        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        headers = get_dss_auth_header(audience=settings.dss_self_audience, token_type="rid")
 
         dss_base_url = settings.dss_base_url
         sub_id = str(uuid.uuid4())

--- a/src/flight_blender/tasks/surveillance.py
+++ b/src/flight_blender/tasks/surveillance.py
@@ -3,14 +3,133 @@ Celery tasks for surveillance monitoring (heartbeat and track dispatch).
 """
 
 from datetime import datetime, timezone
+from typing import Any
 
 from loguru import logger
 
 from flight_blender.tasks.celery_app import celery_app
 
+# SDSP SLA thresholds (mirrors the Django surveillance heartbeat computation).
+# Latency is derived from observation timestamps vs ``now``; accuracy from the
+# reported horizontal / vertical accuracy of the observations in the stream.
+SLA_LATENCY_THRESHOLD_MS = 1000.0
+SLA_ACCURACY_THRESHOLD_M = 10.0
+
+
+def _percentile(values: list[float], pct: float) -> float | None:
+    """Return the ``pct`` (0-100) percentile of *values* using nearest-rank.
+
+    Returns ``None`` for an empty input. Single-value inputs return that value.
+    """
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = max(1, min(len(ordered), round(pct / 100.0 * len(ordered))))
+    return ordered[rank - 1]
+
+
+def _coerce_float(value: Any) -> float | None:
+    """Best-effort float coercion; returns ``None`` on failure."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _observation_latency_ms(observation: dict, now: datetime) -> float | None:
+    """Latency (ms) of one observation = ``now`` minus its timestamp.
+
+    Tolerates a handful of timestamp encodings (ISO-8601 string, epoch seconds,
+    or an already-parsed ``datetime``). Returns ``None`` when not parsable.
+    """
+    ts = observation.get("timestamp") or observation.get("time_stamp")
+    if ts is None:
+        return None
+    parsed: datetime | None = None
+    if isinstance(ts, datetime):
+        parsed = ts
+    elif isinstance(ts, (int, float)):
+        parsed = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+    elif isinstance(ts, str):
+        try:
+            parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            epoch = _coerce_float(ts)
+            if epoch is not None:
+                parsed = datetime.fromtimestamp(epoch, tz=timezone.utc)
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    delta_ms = (now - parsed).total_seconds() * 1000.0
+    return max(0.0, delta_ms)
+
+
+def _observation_accuracy_m(observation: dict) -> float | None:
+    """Worst (largest) of the horizontal / vertical accuracy of an observation."""
+    candidates = [
+        _coerce_float(observation.get("horizontal_accuracy_m")),
+        _coerce_float(observation.get("vertical_accuracy_m")),
+        _coerce_float(observation.get("horizontal_accuracy")),
+        _coerce_float(observation.get("vertical_accuracy")),
+    ]
+    present = [c for c in candidates if c is not None]
+    return max(present) if present else None
+
+
+def compute_sdsp_heartbeat(observations: list[dict], now: datetime | None = None) -> dict:
+    """Derive SDSP heartbeat SLA metrics from the live observation stream.
+
+    Replaces the previously hard-coded "always healthy" heartbeat values. The
+    metrics mirror the Django surveillance heartbeat:
+
+    * ``average_latency_or_95_percentile_latency_ms`` — 95th-percentile latency
+      across observations (``now`` minus each observation timestamp).
+    * ``horizontal_or_vertical_95_percentile_accuracy_m`` — 95th-percentile of
+      the worst-axis accuracy across observations.
+    * ``meets_sla_surveillance_requirements`` — True only when there is data and
+      both latency and accuracy are within their SLA thresholds.
+    * ``meets_sla_rr_lr_requirements`` — True only when there is fresh data
+      (latency within the threshold).
+
+    An empty stream is reported as degraded (both SLA booleans ``False`` and
+    ``None`` latency/accuracy) rather than falsely healthy.
+    """
+    from flight_blender.config import get_settings
+
+    settings = get_settings()
+    now = now or datetime.now(tz=timezone.utc)
+
+    latencies = [v for v in (_observation_latency_ms(o, now) for o in observations) if v is not None]
+    accuracies = [v for v in (_observation_accuracy_m(o) for o in observations) if v is not None]
+
+    latency_p95 = _percentile(latencies, 95.0)
+    accuracy_p95 = _percentile(accuracies, 95.0)
+
+    has_data = bool(observations) and latency_p95 is not None
+    latency_ok = latency_p95 is not None and latency_p95 <= SLA_LATENCY_THRESHOLD_MS
+    accuracy_ok = accuracy_p95 is None or accuracy_p95 <= SLA_ACCURACY_THRESHOLD_M
+
+    meets_surveillance_sla = bool(has_data and latency_ok and accuracy_ok)
+    meets_rr_lr_sla = bool(has_data and latency_ok)
+
+    return {
+        "surveillance_sdsp_name": settings.surveillance_sdsp_name,
+        "meets_sla_surveillance_requirements": meets_surveillance_sla,
+        "meets_sla_rr_lr_requirements": meets_rr_lr_sla,
+        "average_latency_or_95_percentile_latency_ms": (round(latency_p95, 3) if latency_p95 is not None else None),
+        "horizontal_or_vertical_95_percentile_accuracy_m": (round(accuracy_p95, 3) if accuracy_p95 is not None else None),
+        "timestamp": now.isoformat(),
+    }
+
 
 def _get_sync_engine():
     from sqlalchemy import create_engine
+
     from flight_blender.config import get_settings
 
     settings = get_settings()
@@ -25,9 +144,11 @@ def send_heartbeat_to_consumer(self, session_id: str):
     Records timing accuracy and broadcasts via WebSocket channel layer.
     """
     try:
-        from sqlalchemy.orm import Session
-        from flight_blender.models.surveillance import SurveillanceHeartbeatEvent, SurveillanceSession
         import uuid
+
+        from sqlalchemy.orm import Session
+
+        from flight_blender.models.surveillance import SurveillanceHeartbeatEvent, SurveillanceSession
 
         engine = _get_sync_engine()
 
@@ -60,10 +181,12 @@ def send_and_generate_track_to_consumer(self, session_id: str):
     Generate track messages from fused observations and broadcast via channels.
     """
     try:
-        from sqlalchemy.orm import Session
-        from flight_blender.models.surveillance import SurveillanceSession, SurveillanceTrackEvent
-        from datetime import datetime, timezone
         import uuid
+        from datetime import datetime, timezone
+
+        from sqlalchemy.orm import Session
+
+        from flight_blender.models.surveillance import SurveillanceSession, SurveillanceTrackEvent
 
         engine = _get_sync_engine()
 
@@ -96,11 +219,13 @@ def send_and_generate_track_to_consumer(self, session_id: str):
 def cleanup_old_heartbeat_events():
     """Delete heartbeat events older than HEARTBEAT_RETENTION_DAYS."""
     try:
+        from datetime import timedelta
+
         from sqlalchemy import create_engine, delete
         from sqlalchemy.orm import Session
+
         from flight_blender.config import get_settings
         from flight_blender.models.surveillance import SurveillanceHeartbeatEvent
-        from datetime import timedelta
 
         settings = get_settings()
         sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")

--- a/src/flight_blender/tasks/surveillance.py
+++ b/src/flight_blender/tasks/surveillance.py
@@ -128,13 +128,10 @@ def compute_sdsp_heartbeat(observations: list[dict], now: datetime | None = None
 
 
 def _get_sync_engine():
-    from sqlalchemy import create_engine
-
+    from flight_blender.common.sync_engine import get_sync_engine
     from flight_blender.config import get_settings
 
-    settings = get_settings()
-    sync_url = settings.database_url.replace("+aiosqlite", "").replace("+asyncpg", "+psycopg2")
-    return create_engine(sync_url)
+    return get_sync_engine(get_settings().database_url)
 
 
 @celery_app.task(name="send_heartbeat_to_consumer", bind=True)

--- a/src/flight_blender/websocket/__init__.py
+++ b/src/flight_blender/websocket/__init__.py
@@ -5,14 +5,38 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect, status
 from loguru import logger
 
-from flight_blender.websocket.manager import manager, ConnectionManager
+from flight_blender.auth.jwt_bearer import verify_bearer_token
+from flight_blender.config import get_settings
+from flight_blender.websocket.manager import ConnectionManager, manager
+
+settings = get_settings()
 
 ws_router = APIRouter()
 
 __all__ = ["manager", "ConnectionManager", "ws_router"]
+
+
+async def _authorize_ws(websocket: WebSocket, required_scope: str) -> bool:
+    """Authorise a WebSocket handshake before accepting it.
+
+    The bearer token is read from the ``token`` query parameter (browsers cannot
+    set Authorization headers on WebSocket connections). Honors the auth bypass
+    via ``verify_bearer_token``. On failure the handshake is closed with a
+    policy-violation code and ``False`` is returned so the caller can stop.
+    """
+    token = websocket.query_params.get("token")
+    try:
+        payload = verify_bearer_token(token)
+    except HTTPException:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return False
+    if required_scope not in set((payload.get("scope") or "").split()):
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return False
+    return True
 
 
 async def _handle_ws_auth(websocket: WebSocket) -> None:
@@ -41,6 +65,8 @@ async def websocket_heartbeat(websocket: WebSocket, session_id: str):
 
         {"heartbeat_data": {"timestamp": "...", ...}}
     """
+    if not await _authorize_ws(websocket, settings.flightblender_read_scope):
+        return
     channel = f"heartbeat:{session_id}"
     await manager.connect(websocket, channel)
     logger.info("Heartbeat WebSocket connected for session %s", session_id)
@@ -76,6 +102,8 @@ async def websocket_track(websocket: WebSocket, session_id: str):
 
         {"track_data": [{...TrackMessage...}, ...]}
     """
+    if not await _authorize_ws(websocket, settings.flightblender_read_scope):
+        return
     channel = f"track:{session_id}"
     await manager.connect(websocket, channel)
     logger.info("Track WebSocket connected for session %s", session_id)

--- a/src/flight_blender/websocket/__init__.py
+++ b/src/flight_blender/websocket/__init__.py
@@ -76,15 +76,14 @@ async def websocket_heartbeat(websocket: WebSocket, session_id: str):
 
     try:
         while True:
+            # Derive the heartbeat SLA metrics from the live observation stream
+            # instead of emitting hard-coded "healthy" constants.
+            from flight_blender.common.redis_stream_operations import read_all_observations
+            from flight_blender.tasks.surveillance import compute_sdsp_heartbeat
+
             now = datetime.now(tz=timezone.utc)
-            heartbeat_data = {
-                "surveillance_sdsp_name": "Flight Blender SDSP",
-                "meets_sla_surveillance_requirements": True,
-                "meets_sla_rr_lr_requirements": True,
-                "average_latency_or_95_percentile_latency_ms": 50,
-                "horizontal_or_vertical_95_percentile_accuracy_m": 5.0,
-                "timestamp": now.isoformat(),
-            }
+            observations = read_all_observations(session_id=session_id, count=500)
+            heartbeat_data = compute_sdsp_heartbeat(observations, now=now)
             await websocket.send_json({"heartbeat_data": heartbeat_data})
             await asyncio.sleep(1)
     except WebSocketDisconnect:

--- a/src/flight_blender/websocket/__init__.py
+++ b/src/flight_blender/websocket/__init__.py
@@ -9,7 +9,10 @@ from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect, st
 from loguru import logger
 
 from flight_blender.auth.jwt_bearer import verify_bearer_token
+from flight_blender.common.redis_stream_operations import async_read_all_observations
 from flight_blender.config import get_settings
+from flight_blender.services.traffic_data_fuser import DefaultTrafficDataFuser
+from flight_blender.tasks.surveillance import compute_sdsp_heartbeat
 from flight_blender.websocket.manager import ConnectionManager, manager
 
 settings = get_settings()
@@ -53,8 +56,8 @@ async def _handle_ws_auth(websocket: WebSocket) -> None:
     except asyncio.TimeoutError:
         # No auth message within timeout — that's fine for other clients
         pass
-    except Exception:  # nosec B110
-        pass
+    except Exception as exc:
+        logger.debug("WebSocket auth message handling failed: {}", exc)
 
 
 @ws_router.websocket("/ws/surveillance/heartbeat/{session_id}")
@@ -76,20 +79,16 @@ async def websocket_heartbeat(websocket: WebSocket, session_id: str):
 
     try:
         while True:
-            # Derive the heartbeat SLA metrics from the live observation stream
-            # instead of emitting hard-coded "healthy" constants.
-            from flight_blender.common.redis_stream_operations import read_all_observations
-            from flight_blender.tasks.surveillance import compute_sdsp_heartbeat
-
             now = datetime.now(tz=timezone.utc)
-            observations = read_all_observations(session_id=session_id, count=500)
+            observations = await async_read_all_observations(session_id=session_id, count=500)
             heartbeat_data = compute_sdsp_heartbeat(observations, now=now)
             await websocket.send_json({"heartbeat_data": heartbeat_data})
             await asyncio.sleep(1)
     except WebSocketDisconnect:
         manager.disconnect(websocket, channel)
         logger.info("Heartbeat WebSocket disconnected for session %s", session_id)
-    except Exception:
+    except Exception as exc:
+        logger.error("Heartbeat WebSocket error for session %s: %s", session_id, exc)
         manager.disconnect(websocket, channel)
 
 
@@ -112,11 +111,7 @@ async def websocket_track(websocket: WebSocket, session_id: str):
 
     try:
         while True:
-            # Read latest observations from Redis stream
-            from flight_blender.common.redis_stream_operations import read_all_observations
-            from flight_blender.services.traffic_data_fuser import DefaultTrafficDataFuser
-
-            observations = read_all_observations(session_id=session_id, count=500)
+            observations = await async_read_all_observations(session_id=session_id, count=500)
 
             if observations:
                 fuser = DefaultTrafficDataFuser(session_id=session_id, raw_observations=observations)
@@ -139,5 +134,6 @@ async def websocket_track(websocket: WebSocket, session_id: str):
     except WebSocketDisconnect:
         manager.disconnect(websocket, channel)
         logger.info("Track WebSocket disconnected for session %s", session_id)
-    except Exception:
+    except Exception as exc:
+        logger.error("Track WebSocket error for session %s: %s", session_id, exc)
         manager.disconnect(websocket, channel)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,8 @@ async def test_engine():
     ``AsyncSessionLocal`` inside ``flight_blender.database`` are patched so
     that both the FastAPI lifespan and ``get_db`` use the test database.
     """
-    import flight_blender.models  # noqa: F401 – registers all ORM models with Base
     import flight_blender.database as db_module
+    import flight_blender.models  # noqa: F401 – registers all ORM models with Base
     from flight_blender.database import Base
 
     engine = create_async_engine(
@@ -110,18 +110,33 @@ async def client(db):
     with (
         patch("flight_blender.routers.flight_feed.write_incoming_air_traffic_data") as _mock_write,
         patch("flight_blender.routers.flight_feed.bulk_write_incoming_air_traffic_data") as _mock_bulk,
+        patch("flight_blender.routers.flight_feed.send_operational_update_message") as _mock_feed_notify,
         patch("flight_blender.routers.flight_declaration.submit_flight_declaration_to_dss_async") as _mock_dss,
         patch("flight_blender.routers.geo_fence.write_geo_zone") as _mock_wgz,
         patch("flight_blender.routers.geo_fence.download_geozone_source") as _mock_dl,
         patch("flight_blender.routers.rid.submit_dss_subscription") as _mock_sub,
         patch("flight_blender.routers.flight_feed.read_all_observations", return_value=[]),
+        patch("flight_blender.routers.uss.read_all_observations", return_value=[]),
         patch("flight_blender.routers.surveillance.send_heartbeat_to_consumer") as _mock_hb,
         patch("flight_blender.routers.surveillance.send_and_generate_track_to_consumer") as _mock_track,
         patch("flight_blender.tasks.flight_feed.write_incoming_air_traffic_data") as _mock_utm_write,
         patch(
             "flight_blender.services.weather_service.WeatherService.get_weather",
             new_callable=AsyncMock,
-            return_value={"current_weather": {}, "hourly": {}},
+            # Django parity: the upstream Open-Meteo object is returned as-is and
+            # serialized to the WeatherSerializer shape (no synthetic
+            # ``current_weather`` field; lat/lon come from the upstream response).
+            return_value={
+                "latitude": 51.5,
+                "longitude": -0.1,
+                "generationtime_ms": 0.123,
+                "utc_offset_seconds": 0,
+                "timezone": "UTC",
+                "timezone_abbreviation": "GMT",
+                "elevation": 25.0,
+                "hourly_units": {"time": "iso8601", "temperature_2m": "°C"},
+                "hourly": {"time": ["2026-05-30T00:00"], "temperature_2m": [12.3]},
+            },
         ),
     ):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:

--- a/tests/test_auth_verification.py
+++ b/tests/test_auth_verification.py
@@ -64,6 +64,7 @@ def use_jwks(monkeypatch):
                 return types.SimpleNamespace(key=public_key)
 
         monkeypatch.setattr(jb.jwt, "PyJWKClient", _FakeJWKClient)
+        jb._get_jwks_client.cache_clear()
 
     return _install
 

--- a/tests/test_auth_verification.py
+++ b/tests/test_auth_verification.py
@@ -1,0 +1,194 @@
+"""
+Auth-layer verification tests for the real (non-bypassed) JWT path.
+
+The rest of the suite runs with BYPASS_AUTH_TOKEN_VERIFICATION=1, so the
+genuine signature/audience/required-claim checks are never exercised there.
+These tests patch ``jwt_bearer.settings`` with the bypass switched OFF and
+drive ``_get_token_payload`` directly, signing real RS256 tokens with an
+in-test RSA keypair (only the JWKS *fetch* is faked — ``jwt.decode`` runs for
+real).
+
+They pin the hardened posture that matches the Django original:
+  * fail CLOSED when no JWKS URI is configured (never decode unverified),
+  * verify ``audience`` when an expected audience is configured,
+  * require ``exp`` (no never-expiring tokens) and ``iss`` to be present.
+"""
+
+import time
+import types
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+import flight_blender.auth.jwt_bearer as jb
+
+
+def _keypair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key, private_key.public_key()
+
+
+def _sign(private_key, **claims) -> str:
+    return jwt.encode(claims, private_key, algorithm="RS256")
+
+
+def _creds(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def _settings(**overrides):
+    base = dict(
+        bypass_auth_token_verification=False,
+        auth_server_jwks_uri="",
+        auth_audience="",
+        flightblender_read_scope="blender.read",
+        flightblender_write_scope="blender.write",
+    )
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+@pytest.fixture
+def use_jwks(monkeypatch):
+    """Install a fake PyJWKClient whose signing key is the given public key."""
+
+    def _install(public_key):
+        class _FakeJWKClient:
+            def __init__(self, *_a, **_kw):
+                pass
+
+            def get_signing_key_from_jwt(self, _token):
+                return types.SimpleNamespace(key=public_key)
+
+        monkeypatch.setattr(jb.jwt, "PyJWKClient", _FakeJWKClient)
+
+    return _install
+
+
+def _valid_claims(**overrides):
+    claims = {
+        "exp": int(time.time()) + 3600,
+        "iss": "https://issuer.example.test",
+        "aud": "flightblender.test",
+        "scope": "blender.read blender.write",
+    }
+    claims.update(overrides)
+    return claims
+
+
+# ── Fail-closed when JWKS is not configured ─────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_fail_closed_when_jwks_unset(monkeypatch):
+    """No JWKS URI + bypass off must reject, not decode-without-verification."""
+    monkeypatch.setattr(jb, "settings", _settings(auth_server_jwks_uri=""))
+    with pytest.raises(HTTPException) as exc:
+        await jb._get_token_payload(_creds("any.unverifiable.token"))
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_missing_credentials_rejected(monkeypatch):
+    monkeypatch.setattr(jb, "settings", _settings(auth_server_jwks_uri="https://jwks.test"))
+    with pytest.raises(HTTPException) as exc:
+        await jb._get_token_payload(None)
+    assert exc.value.status_code == 401
+
+
+# ── Audience verification ───────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_wrong_audience_rejected(monkeypatch, use_jwks):
+    private_key, public_key = _keypair()
+    use_jwks(public_key)
+    monkeypatch.setattr(
+        jb,
+        "settings",
+        _settings(auth_server_jwks_uri="https://jwks.test", auth_audience="flightblender.test"),
+    )
+    token = _sign(private_key, **_valid_claims(aud="some-other-service"))
+    with pytest.raises(HTTPException) as exc:
+        await jb._get_token_payload(_creds(token))
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_correct_audience_accepted(monkeypatch, use_jwks):
+    private_key, public_key = _keypair()
+    use_jwks(public_key)
+    monkeypatch.setattr(
+        jb,
+        "settings",
+        _settings(auth_server_jwks_uri="https://jwks.test", auth_audience="flightblender.test"),
+    )
+    token = _sign(private_key, **_valid_claims(aud="flightblender.test"))
+    payload = await jb._get_token_payload(_creds(token))
+    assert payload["scope"] == "blender.read blender.write"
+
+
+# ── Required claims ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_missing_exp_rejected(monkeypatch, use_jwks):
+    private_key, public_key = _keypair()
+    use_jwks(public_key)
+    monkeypatch.setattr(
+        jb,
+        "settings",
+        _settings(auth_server_jwks_uri="https://jwks.test", auth_audience="flightblender.test"),
+    )
+    claims = _valid_claims()
+    claims.pop("exp")
+    token = _sign(private_key, **claims)
+    with pytest.raises(HTTPException) as exc:
+        await jb._get_token_payload(_creds(token))
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_missing_iss_rejected(monkeypatch, use_jwks):
+    private_key, public_key = _keypair()
+    use_jwks(public_key)
+    monkeypatch.setattr(
+        jb,
+        "settings",
+        _settings(auth_server_jwks_uri="https://jwks.test", auth_audience="flightblender.test"),
+    )
+    claims = _valid_claims()
+    claims.pop("iss")
+    token = _sign(private_key, **claims)
+    with pytest.raises(HTTPException) as exc:
+        await jb._get_token_payload(_creds(token))
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_expired_token_rejected(monkeypatch, use_jwks):
+    private_key, public_key = _keypair()
+    use_jwks(public_key)
+    monkeypatch.setattr(
+        jb,
+        "settings",
+        _settings(auth_server_jwks_uri="https://jwks.test", auth_audience="flightblender.test"),
+    )
+    token = _sign(private_key, **_valid_claims(exp=int(time.time()) - 10))
+    with pytest.raises(HTTPException) as exc:
+        await jb._get_token_payload(_creds(token))
+    assert exc.value.status_code == 401
+
+
+# ── Bypass still works (dev/test convenience) ───────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_bypass_returns_all_scopes(monkeypatch):
+    monkeypatch.setattr(jb, "settings", _settings(bypass_auth_token_verification=True))
+    payload = await jb._get_token_payload(None)
+    assert "blender.read" in payload["scope"]
+    assert "blender.write" in payload["scope"]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -77,6 +77,13 @@ class TestRedisClient:
         rc._async_pool = None
         rc._sync_client = None
 
+    def teardown_method(self):
+        """Reset module-level singletons after each test to avoid leaking mocks."""
+        import flight_blender.common.redis_client as rc
+
+        rc._async_pool = None
+        rc._sync_client = None
+
     def test_get_async_redis_creates_instance(self):
         mock_redis = MagicMock()
         with patch("flight_blender.common.redis_client.aioredis.Redis", return_value=mock_redis):

--- a/tests/test_compose_beat.py
+++ b/tests/test_compose_beat.py
@@ -1,0 +1,36 @@
+"""
+Deployment regression guard: the Celery **beat** scheduler must be enabled in
+the production compose file. Without a beat process, no scheduled task ever runs
+(heartbeat cleanup, and — once wired — periodic conformance/DSS reconciliation),
+even though tasks are defined. The beat service had been commented out.
+"""
+
+import pathlib
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+COMPOSE = pathlib.Path(__file__).resolve().parents[1] / "docker-compose.yml"
+BEAT_SERVICE = "flight-blender-celery-beat"
+
+
+def _services() -> dict:
+    return yaml.safe_load(COMPOSE.read_text()).get("services", {})
+
+
+def test_beat_service_enabled_in_prod_compose():
+    services = _services()
+    assert BEAT_SERVICE in services, f"{BEAT_SERVICE} must be enabled (uncommented) in docker-compose.yml"
+
+
+def test_beat_runs_the_beat_entrypoint():
+    beat = _services()[BEAT_SERVICE]
+    assert "entrypoint-beat.sh" in beat["command"], "beat service must run the beat entrypoint"
+
+
+def test_beat_depends_on_db_and_redis():
+    beat = _services()[BEAT_SERVICE]
+    deps = beat.get("depends_on", {})
+    dep_names = set(deps) if isinstance(deps, (list, dict)) else set()
+    assert {"redis-blender", "db-blender"} <= dep_names, "beat must wait for redis and db"

--- a/tests/test_conformance_engine.py
+++ b/tests/test_conformance_engine.py
@@ -1,0 +1,268 @@
+"""
+Unit tests for the pure conformance check engine.
+
+These tests exercise the C2-C11 conformance logic ported from the Django
+``conformance_monitoring_operations.utils.FlightBlenderConformanceEngine``.
+They are pure-logic tests: no database, no network, no Celery.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from flight_blender.services.conformance_engine import (
+    ConformanceCheck,
+    GeoFencePolygon,
+    OperationalIntentSnapshot,
+    TelemetryObservation,
+    VolumeBound,
+    check_operation_conformant_via_telemetry,
+    check_operational_intent_reference_conformance,
+    point_in_polygon,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _square_volume(
+    *,
+    min_lng: float = 0.0,
+    min_lat: float = 0.0,
+    max_lng: float = 1.0,
+    max_lat: float = 1.0,
+    altitude_lower: float = 0.0,
+    altitude_upper: float = 120.0,
+) -> VolumeBound:
+    """A square volume from (min_lng, min_lat) to (max_lng, max_lat)."""
+    return VolumeBound(
+        vertices=[
+            (min_lng, min_lat),
+            (max_lng, min_lat),
+            (max_lng, max_lat),
+            (min_lng, max_lat),
+        ],
+        altitude_lower=altitude_lower,
+        altitude_upper=altitude_upper,
+    )
+
+
+def _snapshot(**overrides) -> OperationalIntentSnapshot:
+    defaults = dict(
+        aircraft_id="abc-123",
+        state=2,  # Activated
+        start_datetime=_now() - timedelta(hours=1),
+        end_datetime=_now() + timedelta(hours=1),
+        volumes=[_square_volume()],
+        operational_intent_reference_exists=True,
+    )
+    defaults.update(overrides)
+    return OperationalIntentSnapshot(**defaults)
+
+
+def _telemetry(**overrides) -> TelemetryObservation:
+    defaults = dict(aircraft_id="abc-123", lat=0.5, lng=0.5, altitude_m_wgs_84=50.0)
+    defaults.update(overrides)
+    return TelemetryObservation(**defaults)
+
+
+# --------------------------------------------------------------------------- #
+# point_in_polygon geometry helper
+# --------------------------------------------------------------------------- #
+
+
+def test_point_in_polygon_inside():
+    square = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+    assert point_in_polygon(0.5, 0.5, square) is True
+
+
+def test_point_in_polygon_outside():
+    square = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+    assert point_in_polygon(5.0, 5.0, square) is False
+
+
+def test_point_in_polygon_degenerate_returns_false():
+    assert point_in_polygon(0.0, 0.0, [(0.0, 0.0), (1.0, 1.0)]) is False
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry-based conformance (C2-C8)
+# --------------------------------------------------------------------------- #
+
+
+def test_conforming_case_returns_conformant():
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(),
+        telemetry=_telemetry(),
+        geofences=[],
+    )
+    assert result is ConformanceCheck.CONFORMANT
+
+
+def test_c2_missing_operational_intent_reference():
+    """C2: when USSP network enabled and op-intent reference is absent."""
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(operational_intent_reference_exists=False),
+        telemetry=_telemetry(),
+        geofences=[],
+        ussp_network_enabled=True,
+    )
+    assert result is ConformanceCheck.C2
+
+
+def test_c2_skipped_when_ussp_network_disabled():
+    """With the USSP network disabled, a missing reference must NOT trip C2."""
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(operational_intent_reference_exists=False),
+        telemetry=_telemetry(),
+        geofences=[],
+        ussp_network_enabled=False,
+    )
+    assert result is ConformanceCheck.CONFORMANT
+
+
+def test_c3_aircraft_id_mismatch():
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(aircraft_id="abc-123"),
+        telemetry=_telemetry(aircraft_id="other-999"),
+        geofences=[],
+    )
+    assert result is ConformanceCheck.C3
+
+
+def test_c4_invalid_state():
+    """States 0, 5, 6, 7, 8 are invalid for an active operation (C4)."""
+    for invalid_state in (0, 5, 6, 7, 8):
+        result = check_operation_conformant_via_telemetry(
+            snapshot=_snapshot(state=invalid_state),
+            telemetry=_telemetry(),
+            geofences=[],
+        )
+        assert result is ConformanceCheck.C4, f"state={invalid_state}"
+
+
+def test_c5_not_activated_state():
+    """State 1 (Accepted) is valid but not yet activated (C5)."""
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(state=1),
+        telemetry=_telemetry(),
+        geofences=[],
+    )
+    assert result is ConformanceCheck.C5
+
+
+def test_c6_telemetry_outside_time_window():
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(
+            start_datetime=_now() - timedelta(hours=3),
+            end_datetime=_now() - timedelta(hours=2),
+        ),
+        telemetry=_telemetry(),
+        geofences=[],
+    )
+    assert result is ConformanceCheck.C6
+
+
+def test_c7a_outside_horizontal_volume():
+    """Inside altitude band but outside the polygon footprint -> C7a."""
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(volumes=[_square_volume(altitude_lower=0.0, altitude_upper=120.0)]),
+        telemetry=_telemetry(lat=5.0, lng=5.0, altitude_m_wgs_84=50.0),
+        geofences=[],
+    )
+    assert result is ConformanceCheck.C7a
+
+
+def test_c7b_outside_altitude_band():
+    """Inside the footprint but above the altitude ceiling -> C7b."""
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(volumes=[_square_volume(altitude_lower=0.0, altitude_upper=120.0)]),
+        telemetry=_telemetry(lat=0.5, lng=0.5, altitude_m_wgs_84=500.0),
+        geofences=[],
+    )
+    assert result is ConformanceCheck.C7b
+
+
+def test_c8_geofence_breach():
+    """Aircraft inside the operating volume but also inside an active geofence -> C8."""
+    breaching_fence = GeoFencePolygon(vertices=[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)])
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(),
+        telemetry=_telemetry(lat=0.5, lng=0.5),
+        geofences=[breaching_fence],
+    )
+    assert result is ConformanceCheck.C8
+
+
+def test_geofence_not_breached_is_conformant():
+    far_fence = GeoFencePolygon(vertices=[(10.0, 10.0), (11.0, 10.0), (11.0, 11.0), (10.0, 11.0)])
+    result = check_operation_conformant_via_telemetry(
+        snapshot=_snapshot(),
+        telemetry=_telemetry(lat=0.5, lng=0.5),
+        geofences=[far_fence],
+    )
+    assert result is ConformanceCheck.CONFORMANT
+
+
+# --------------------------------------------------------------------------- #
+# Operational-intent-reference conformance (C9-C11)
+# --------------------------------------------------------------------------- #
+
+
+def test_op_intent_conformance_conforming():
+    result = check_operational_intent_reference_conformance(
+        state=2,
+        latest_telemetry_datetime=_now(),
+        operational_intent_reference_exists=True,
+    )
+    assert result is ConformanceCheck.CONFORMANT
+
+
+def test_c11_missing_operational_intent_reference():
+    result = check_operational_intent_reference_conformance(
+        state=2,
+        latest_telemetry_datetime=_now(),
+        operational_intent_reference_exists=False,
+        ussp_network_enabled=True,
+    )
+    assert result is ConformanceCheck.C11
+
+
+def test_c11_skipped_when_ussp_disabled():
+    result = check_operational_intent_reference_conformance(
+        state=2,
+        latest_telemetry_datetime=_now(),
+        operational_intent_reference_exists=False,
+        ussp_network_enabled=False,
+    )
+    assert result is ConformanceCheck.CONFORMANT
+
+
+def test_c10_invalid_state():
+    """Only states 2, 3, 4 are allowed for an active op-intent (C10)."""
+    for invalid_state in (0, 1, 5, 6, 7, 8):
+        result = check_operational_intent_reference_conformance(
+            state=invalid_state,
+            latest_telemetry_datetime=_now(),
+            operational_intent_reference_exists=True,
+        )
+        assert result is ConformanceCheck.C10, f"state={invalid_state}"
+
+
+def test_c9b_stale_telemetry():
+    """Telemetry exists but is older than the 15-second liveness window -> C9b."""
+    result = check_operational_intent_reference_conformance(
+        state=2,
+        latest_telemetry_datetime=_now() - timedelta(minutes=5),
+        operational_intent_reference_exists=True,
+    )
+    assert result is ConformanceCheck.C9b
+
+
+def test_c9a_absent_telemetry():
+    """No telemetry at all -> C9a (contingent)."""
+    result = check_operational_intent_reference_conformance(
+        state=2,
+        latest_telemetry_datetime=None,
+        operational_intent_reference_exists=True,
+    )
+    assert result is ConformanceCheck.C9a

--- a/tests/test_conformance_schedule.py
+++ b/tests/test_conformance_schedule.py
@@ -1,0 +1,47 @@
+"""
+Tests that periodic conformance monitoring is scheduled via Celery beat and
+that the periodic dispatcher fans out to active operations.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from flight_blender.tasks.celery_app import celery_app
+
+
+def test_beat_schedule_has_conformance_entry():
+    schedule = celery_app.conf.beat_schedule
+    assert "periodic-conformance-check" in schedule
+
+
+def test_conformance_schedule_runs_the_conformance_task():
+    entry = celery_app.conf.beat_schedule["periodic-conformance-check"]
+    assert entry["task"] == "check_all_flight_conformance"
+    # runs on a finite, positive period
+    assert isinstance(entry["schedule"], (int, float))
+    assert entry["schedule"] > 0
+
+
+def test_check_all_flight_conformance_dispatches_active_declarations():
+    """The periodic dispatcher should schedule a check for each active op."""
+    from flight_blender.tasks.conformance import check_all_flight_conformance
+
+    decl = MagicMock()
+    decl.id = uuid.uuid4()
+    decl.state = 2
+    decl.start_datetime = datetime.now(timezone.utc) - timedelta(hours=1)
+    decl.end_datetime = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    with (
+        patch("flight_blender.tasks.conformance.create_engine"),
+        patch("flight_blender.tasks.conformance.Session") as mock_session_cls,
+        patch("flight_blender.tasks.conformance.check_flight_conformance") as mock_check,
+    ):
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalars.return_value.all.return_value = [decl]
+
+        check_all_flight_conformance()
+
+        mock_check.delay.assert_called_once_with(str(decl.id))

--- a/tests/test_conformance_task_wiring.py
+++ b/tests/test_conformance_task_wiring.py
@@ -1,0 +1,185 @@
+"""
+Tests that the conformance Celery tasks are wired to the real conformance
+engine (rather than the old ``state == 2`` stub).
+
+These use mocked SQLAlchemy sessions / Redis (no real DB, broker or Redis),
+mirroring the patching style in ``tests/test_tasks.py``.
+"""
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+VALID_ID = str(uuid.uuid4())
+
+
+def _decl(state=2, latest_offset_seconds=0, operational_intent="{}"):
+    obj = MagicMock()
+    obj.id = uuid.uuid4()
+    obj.state = state
+    obj.aircraft_id = "abc-123"
+    obj.start_datetime = datetime.now(timezone.utc) - timedelta(hours=1)
+    obj.end_datetime = datetime.now(timezone.utc) + timedelta(hours=1)
+    obj.operational_intent = operational_intent
+    obj.latest_telemetry_datetime = datetime.now(timezone.utc) - timedelta(seconds=latest_offset_seconds)
+    return obj
+
+
+def test_flight_conformance_conforming_record():
+    """Activated op with fresh telemetry -> conforming record."""
+    from flight_blender.tasks.conformance import check_flight_conformance
+
+    with (
+        patch("flight_blender.tasks.conformance.create_engine"),
+        patch("flight_blender.tasks.conformance.Session") as mock_session_cls,
+    ):
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__.return_value = mock_session
+        mock_session.get.return_value = _decl(state=2, latest_offset_seconds=0)
+
+        check_flight_conformance(VALID_ID)
+
+        added = mock_session.add.call_args[0][0]
+        assert added.conformance_state == 1
+        assert added.resolved is True
+        assert added.geofence_breach is False
+        mock_session.commit.assert_called_once()
+
+
+def test_flight_conformance_stale_telemetry_marks_non_conforming():
+    """Activated op with stale telemetry should fail liveness (C9b) -> non-conforming."""
+    from flight_blender.tasks.conformance import check_flight_conformance
+
+    with (
+        patch("flight_blender.tasks.conformance.create_engine"),
+        patch("flight_blender.tasks.conformance.Session") as mock_session_cls,
+    ):
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__.return_value = mock_session
+        mock_session.get.return_value = _decl(state=2, latest_offset_seconds=600)
+
+        check_flight_conformance(VALID_ID)
+
+        added = mock_session.add.call_args[0][0]
+        assert added.conformance_state == 0
+        assert added.geofence_breach is False
+        assert "C9b" in added.description
+
+
+def test_flight_conformance_records_check_code_in_description():
+    """A non-active state (Accepted) fails C10 and is named in the description."""
+    from flight_blender.tasks.conformance import check_flight_conformance
+
+    with (
+        patch("flight_blender.tasks.conformance.create_engine"),
+        patch("flight_blender.tasks.conformance.Session") as mock_session_cls,
+    ):
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__.return_value = mock_session
+        mock_session.get.return_value = _decl(state=1)  # Accepted -> C10
+
+        check_flight_conformance(VALID_ID)
+
+        added = mock_session.add.call_args[0][0]
+        assert added.conformance_state == 0
+        assert "C10" in added.description
+
+
+def _operational_intent_square():
+    return json.dumps(
+        {
+            "volumes": [
+                {
+                    "volume": {
+                        "outline_polygon": {
+                            "vertices": [
+                                {"lng": 0.0, "lat": 0.0},
+                                {"lng": 1.0, "lat": 0.0},
+                                {"lng": 1.0, "lat": 1.0},
+                                {"lng": 0.0, "lat": 1.0},
+                            ]
+                        },
+                        "altitude_lower": {"value": 0.0, "reference": "W84", "units": "M"},
+                        "altitude_upper": {"value": 120.0, "reference": "W84", "units": "M"},
+                    },
+                    "time_start": {"value": "2026-01-01T00:00:00Z", "format": "RFC3339"},
+                    "time_end": {"value": "2026-12-31T00:00:00Z", "format": "RFC3339"},
+                }
+            ]
+        }
+    )
+
+
+def test_telemetry_conformance_conforming_inside_volume():
+    """Telemetry inside the volume, no geofence -> conforming telemetry record."""
+    from flight_blender.tasks.conformance import check_operation_telemetry_conformance
+
+    telemetry = {"icao_address": "abc-123", "lat_dd": "0.5", "lon_dd": "0.5", "altitude_mm": "50000"}
+
+    with (
+        patch("flight_blender.tasks.conformance.read_latest_observation", return_value=telemetry),
+        patch("flight_blender.tasks.conformance.create_engine"),
+        patch("flight_blender.tasks.conformance.Session") as mock_session_cls,
+    ):
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__.return_value = mock_session
+        mock_session.get.return_value = _decl(state=2, operational_intent=_operational_intent_square())
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+
+        check_operation_telemetry_conformance(VALID_ID)
+
+        added = mock_session.add.call_args[0][0]
+        assert added.conformance_state == 1
+        assert added.geofence_breach is False
+        assert added.event_type == "telemetry_check"
+
+
+def test_telemetry_conformance_geofence_breach_sets_flag():
+    """When telemetry breaches a geofence the record records a geofence breach (C8)."""
+    from flight_blender.tasks.conformance import check_operation_telemetry_conformance
+
+    telemetry = {"icao_address": "abc-123", "lat_dd": "0.5", "lon_dd": "0.5", "altitude_mm": "50000"}
+    geofence = MagicMock()
+    geofence.raw_geo_fence = json.dumps(
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]],
+                    }
+                }
+            ]
+        }
+    )
+
+    with (
+        patch("flight_blender.tasks.conformance.read_latest_observation", return_value=telemetry),
+        patch("flight_blender.tasks.conformance.create_engine"),
+        patch("flight_blender.tasks.conformance.Session") as mock_session_cls,
+    ):
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__.return_value = mock_session
+        mock_session.get.return_value = _decl(state=2, operational_intent=_operational_intent_square())
+        mock_session.execute.return_value.scalars.return_value.all.return_value = [geofence]
+
+        check_operation_telemetry_conformance(VALID_ID)
+
+        added = mock_session.add.call_args[0][0]
+        assert added.geofence_breach is True
+        assert added.conformance_state == 0
+        assert "C8" in added.description
+
+
+def test_telemetry_conformance_no_observation_is_noop():
+    """No telemetry -> nothing written."""
+    from flight_blender.tasks.conformance import check_operation_telemetry_conformance
+
+    with (
+        patch("flight_blender.tasks.conformance.read_latest_observation", return_value=None),
+        patch("flight_blender.tasks.conformance.create_engine"),
+        patch("flight_blender.tasks.conformance.Session") as mock_session_cls,
+    ):
+        check_operation_telemetry_conformance(VALID_ID)
+        mock_session_cls.assert_not_called()

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1,0 +1,88 @@
+"""Characterization tests for the constraint router GET endpoints.
+
+The FastAPI ``routers/constraint.py`` exposes two read endpoints
+(``GET /constraint_detail/{id}`` and ``GET /constraint_reference/{id}``) backed
+by the ``ConstraintDetail`` / ``ConstraintReference`` SQLAlchemy models.
+
+The Django ``constraint_operations`` app exposes **no** HTTP endpoints
+(``urlpatterns == []`` and an empty ``views.py``); its only logic is the
+DSS/USS *read* helpers (``constraints_helper.py`` /
+``dss_constraints_helper.py``) which query constraints **from** the DSS and peer
+USSes. There is no ``PUT /constraint_reference`` view, no ``GET /constraints``
+view and no ``POST /query`` view to port. These tests therefore pin the
+read-only port that actually exists and guard it against regression.
+"""
+
+import uuid
+
+import pytest
+
+from flight_blender.models.constraint import ConstraintDetail, ConstraintReference
+
+
+@pytest.mark.anyio
+async def test_get_constraint_detail_found_full_shape(client, db):
+    """The detail endpoint returns id, volumes and the mapped ``type`` field."""
+    detail = ConstraintDetail(volumes="[]", _type="EMERGENCY")
+    db.add(detail)
+    await db.flush()
+    await db.commit()
+
+    response = await client.get(f"/constraint_ops/constraint_detail/{detail.id}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "id": str(detail.id),
+        "volumes": "[]",
+        "type": "EMERGENCY",
+    }
+
+
+@pytest.mark.anyio
+async def test_get_constraint_detail_not_found(client):
+    response = await client.get(f"/constraint_ops/constraint_detail/{uuid.uuid4()}")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Constraint detail not found"
+
+
+@pytest.mark.anyio
+async def test_get_constraint_reference_found_full_shape(client, db):
+    """The reference endpoint returns the full serialized reference shape."""
+    ref = ConstraintReference(
+        uss_availability="Normal",
+        ovn="constraint-ovn",
+        manager="manager-1",
+        uss_base_url="https://uss.example.com",
+        version="7",
+        is_live=True,
+    )
+    db.add(ref)
+    await db.flush()
+    await db.commit()
+
+    response = await client.get(f"/constraint_ops/constraint_reference/{ref.id}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "id": str(ref.id),
+        "uss_availability": "Normal",
+        "ovn": "constraint-ovn",
+        "manager": "manager-1",
+        "uss_base_url": "https://uss.example.com",
+        "version": "7",
+        "is_live": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_get_constraint_reference_not_found(client):
+    response = await client.get(f"/constraint_ops/constraint_reference/{uuid.uuid4()}")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Constraint reference not found"
+
+
+@pytest.mark.anyio
+async def test_get_constraint_detail_invalid_uuid_returns_422(client):
+    """A non-UUID path segment is rejected by the ``uuid.UUID`` path type."""
+    response = await client.get("/constraint_ops/constraint_detail/not-a-uuid")
+    assert response.status_code == 422

--- a/tests/test_deconfliction_engine.py
+++ b/tests/test_deconfliction_engine.py
@@ -1,0 +1,237 @@
+"""
+Unit tests for the strategic deconfliction engine.
+
+Pure-logic tests: no DB, no network. They cover the geometric / temporal /
+altitude overlap helpers, the full 4D deconfliction decision, the
+DefaultDeconflictionEngine strategic + bbox checks, and the fail-closed
+decision mapping (``resolve_decision``).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from flight_blender.services.deconfliction import (
+    DeconflictionRequest,
+    DefaultDeconflictionEngine,
+    check_altitude_overlap,
+    check_polygon_intersection,
+    check_time_overlap,
+    deconflict_operational_intent,
+    resolve_decision,
+)
+
+# A square around (-122.4, 37.7) .. (-122.3, 37.8)
+_SQUARE_A = [[-122.4, 37.7], [-122.4, 37.8], [-122.3, 37.8], [-122.3, 37.7], [-122.4, 37.7]]
+# Overlapping square (shifted but still overlapping A)
+_SQUARE_A_OVERLAP = [[-122.35, 37.75], [-122.35, 37.85], [-122.25, 37.85], [-122.25, 37.75], [-122.35, 37.75]]
+# Disjoint square far away
+_SQUARE_FAR = [[-100.0, 30.0], [-100.0, 30.1], [-99.9, 30.1], [-99.9, 30.0], [-100.0, 30.0]]
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+# ── Pure helpers ────────────────────────────────────────────────────────────
+
+
+class TestPolygonIntersection:
+    def test_overlapping_polygons(self):
+        assert check_polygon_intersection(_SQUARE_A, _SQUARE_A_OVERLAP) is True
+
+    def test_disjoint_polygons(self):
+        assert check_polygon_intersection(_SQUARE_A, _SQUARE_FAR) is False
+
+    def test_identical_polygons(self):
+        assert check_polygon_intersection(_SQUARE_A, _SQUARE_A) is True
+
+    def test_degenerate_polygon(self):
+        assert check_polygon_intersection(_SQUARE_A, [[-122.4, 37.7], [-122.4, 37.8]]) is False
+
+
+class TestTimeOverlap:
+    def test_overlapping_time(self):
+        t0 = _now()
+        assert check_time_overlap(t0, t0 + timedelta(hours=2), t0 + timedelta(hours=1), t0 + timedelta(hours=3)) is True
+
+    def test_disjoint_time(self):
+        t0 = _now()
+        assert check_time_overlap(t0, t0 + timedelta(hours=1), t0 + timedelta(hours=2), t0 + timedelta(hours=3)) is False
+
+    def test_touching_time_is_overlap(self):
+        t0 = _now()
+        assert check_time_overlap(t0, t0 + timedelta(hours=1), t0 + timedelta(hours=1), t0 + timedelta(hours=2)) is True
+
+
+class TestAltitudeOverlap:
+    def test_overlapping_altitude(self):
+        assert check_altitude_overlap(50, 120, 100, 200) is True
+
+    def test_disjoint_altitude(self):
+        assert check_altitude_overlap(50, 120, 130, 200) is False
+
+    def test_touching_altitude_is_overlap(self):
+        assert check_altitude_overlap(50, 120, 120, 200) is True
+
+
+# ── Full 4D deconfliction decision ──────────────────────────────────────────
+
+
+class TestDeconflict4D:
+    def _candidate(self, coords=None, start=None, end=None, min_alt=50, max_alt=120):
+        t0 = _now()
+        return {
+            "coordinates": coords or _SQUARE_A,
+            "start": start or t0,
+            "end": end or (t0 + timedelta(hours=2)),
+            "min_alt": min_alt,
+            "max_alt": max_alt,
+        }
+
+    def test_conflict_when_overlap_in_space_time_altitude(self):
+        cand = self._candidate()
+        existing = [self._candidate(coords=_SQUARE_A_OVERLAP)]
+        # clear == False means there IS a conflict
+        assert deconflict_operational_intent(cand, existing) is False
+
+    def test_clear_when_disjoint_in_space(self):
+        cand = self._candidate()
+        existing = [self._candidate(coords=_SQUARE_FAR)]
+        assert deconflict_operational_intent(cand, existing) is True
+
+    def test_clear_when_disjoint_in_time(self):
+        t0 = _now()
+        cand = self._candidate(start=t0, end=t0 + timedelta(hours=1))
+        existing = [self._candidate(coords=_SQUARE_A_OVERLAP, start=t0 + timedelta(hours=2), end=t0 + timedelta(hours=3))]
+        assert deconflict_operational_intent(cand, existing) is True
+
+    def test_clear_when_disjoint_in_altitude(self):
+        cand = self._candidate(min_alt=50, max_alt=120)
+        existing = [self._candidate(coords=_SQUARE_A_OVERLAP, min_alt=200, max_alt=300)]
+        assert deconflict_operational_intent(cand, existing) is True
+
+    def test_clear_with_no_existing(self):
+        assert deconflict_operational_intent(self._candidate(), []) is True
+
+    def test_iso_string_times_supported(self):
+        t0 = _now()
+        cand = {
+            "coordinates": _SQUARE_A,
+            "start": t0.isoformat(),
+            "end": (t0 + timedelta(hours=2)).isoformat(),
+            "min_alt": 50,
+            "max_alt": 120,
+        }
+        existing = [
+            {
+                "coordinates": _SQUARE_A_OVERLAP,
+                "start": (t0 + timedelta(hours=1)).isoformat(),
+                "end": (t0 + timedelta(hours=3)).isoformat(),
+                "min_alt": 50,
+                "max_alt": 120,
+            }
+        ]
+        assert deconflict_operational_intent(cand, existing) is False
+
+
+# ── Engine strategic (volume) check ─────────────────────────────────────────
+
+
+class TestEngineStrategicCheck:
+    def _vol(self, coords, min_alt=50, max_alt=120, hours_offset=0, duration=2):
+        t0 = _now()
+        start = t0 + timedelta(hours=hours_offset)
+        return {
+            "coordinates": coords,
+            "min_alt": min_alt,
+            "max_alt": max_alt,
+            "start": start.isoformat(),
+            "end": (start + timedelta(hours=duration)).isoformat(),
+        }
+
+    def _request(self, candidate_volume, existing_volumes, ussp=0):
+        return DeconflictionRequest(
+            candidate_volume=candidate_volume,
+            prefetched_volumes=existing_volumes,
+            ussp_network_enabled=ussp,
+        )
+
+    def test_conflict_rejects(self):
+        engine = DefaultDeconflictionEngine()
+        result = engine.check_deconfliction(self._request(self._vol(_SQUARE_A), [self._vol(_SQUARE_A_OVERLAP)]))
+        assert result.is_approved is False
+        assert result.declaration_state == 8  # Rejected
+
+    def test_clear_accepts_when_no_network(self):
+        engine = DefaultDeconflictionEngine()
+        result = engine.check_deconfliction(self._request(self._vol(_SQUARE_A), [self._vol(_SQUARE_FAR)], ussp=0))
+        assert result.is_approved is True
+        assert result.declaration_state == 1  # Accepted (no network)
+
+    def test_clear_pending_when_network_enabled(self):
+        engine = DefaultDeconflictionEngine()
+        result = engine.check_deconfliction(self._request(self._vol(_SQUARE_A), [self._vol(_SQUARE_FAR)], ussp=1))
+        assert result.is_approved is True
+        assert result.declaration_state == 0  # NotSubmitted until DSS responds
+
+
+class TestEngineBboxMode:
+    """When no candidate_volume is supplied, the engine runs the legacy Django
+    bbox check against prefetched declarations/fences."""
+
+    def test_bbox_conflict_rejected(self):
+        engine = DefaultDeconflictionEngine()
+        req = DeconflictionRequest(
+            view_box=[-122.4, 37.7, -122.3, 37.8],
+            prefetched_declarations=[{"id": "d1", "bounds": '{"minx": -122.35, "miny": 37.75, "maxx": -122.25, "maxy": 37.85}'}],
+            ussp_network_enabled=0,
+        )
+        result = engine.check_deconfliction(req)
+        assert result.is_approved is False
+        assert result.declaration_state == 8
+
+    def test_bbox_disjoint_accepted(self):
+        engine = DefaultDeconflictionEngine()
+        req = DeconflictionRequest(
+            view_box=[-122.4, 37.7, -122.3, 37.8],
+            prefetched_declarations=[{"id": "d1", "bounds": '{"minx": -100.0, "miny": 30.0, "maxx": -99.9, "maxy": 30.1}'}],
+            ussp_network_enabled=0,
+        )
+        result = engine.check_deconfliction(req)
+        assert result.is_approved is True
+        assert result.declaration_state == 1
+
+    def test_bbox_no_view_box_accepts(self):
+        engine = DefaultDeconflictionEngine()
+        result = engine.check_deconfliction(DeconflictionRequest(view_box=[], ussp_network_enabled=0))
+        assert result.is_approved is True
+        assert result.declaration_state == 1
+
+
+# ── Fail-closed decision logic ──────────────────────────────────────────────
+
+
+class TestFailClosedDecision:
+    def test_engine_error_is_not_approved(self):
+        decision = resolve_decision(engine_error=True, is_clear=True, ussp_network_enabled=0)
+        assert decision.is_approved is False
+        assert decision.declaration_state == 8  # Rejected, never accepted on error
+
+    def test_engine_error_not_approved_even_with_network(self):
+        decision = resolve_decision(engine_error=True, is_clear=True, ussp_network_enabled=1)
+        assert decision.is_approved is False
+        assert decision.declaration_state == 8
+
+    def test_conflict_is_rejected(self):
+        decision = resolve_decision(engine_error=False, is_clear=False, ussp_network_enabled=0)
+        assert decision.is_approved is False
+        assert decision.declaration_state == 8
+
+    def test_clear_accepted_without_network(self):
+        decision = resolve_decision(engine_error=False, is_clear=True, ussp_network_enabled=0)
+        assert decision.is_approved is True
+        assert decision.declaration_state == 1
+
+    def test_clear_pending_with_network(self):
+        decision = resolve_decision(engine_error=False, is_clear=True, ussp_network_enabled=1)
+        assert decision.is_approved is True
+        assert decision.declaration_state == 0

--- a/tests/test_deconfliction_wiring.py
+++ b/tests/test_deconfliction_wiring.py
@@ -1,0 +1,145 @@
+"""
+Wiring + fail-closed tests for the strategic deconfliction path in the
+flight-declaration router.
+
+These exercise the router's ``_run_deconfliction`` glue and the create/ingest
+endpoints, with the deconfliction engine patched so we assert the *decision*
+(approval + resulting state) without any real DB-of-peers or network.
+"""
+
+import unittest.mock as mock
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from flight_blender.routers import flight_declaration as fd_router
+
+pytestmark = pytest.mark.anyio
+
+BASE = "/flight_declaration_ops"
+
+
+def _future_times():
+    start = datetime.now(timezone.utc) + timedelta(hours=1)
+    end = start + timedelta(hours=2)
+    return start.isoformat(), end.isoformat()
+
+
+def _geo_json():
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"min_altitude": {"meters": 50}, "max_altitude": {"meters": 120}},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[-122.4, 37.7], [-122.4, 37.8], [-122.3, 37.8], [-122.3, 37.7], [-122.4, 37.7]]],
+                },
+            }
+        ],
+    }
+
+
+def _payload():
+    start, end = _future_times()
+    return {
+        "aircraft_id": "TEST-AIRCRAFT",
+        "originating_party": "Test Operator",
+        "start_datetime": start,
+        "end_datetime": end,
+        "flight_declaration_geo_json": _geo_json(),
+        "type_of_operation": 0,
+    }
+
+
+class TestFailClosed:
+    async def test_set_flight_declaration_fails_closed_on_engine_error(self, client):
+        """If the deconfliction engine raises, the declaration must NOT be accepted.
+
+        The fail-closed guard lives inside ``_run_deconfliction``; we trigger it
+        by making plugin loading raise, then assert the persisted operation is
+        Rejected rather than silently accepted.
+        """
+        with mock.patch.object(fd_router, "load_plugin", side_effect=RuntimeError("import boom")):
+            resp = await client.post(f"{BASE}/set_flight_declaration", json=_payload())
+        assert resp.status_code in (200, 201)
+        data = resp.json()
+        assert data["is_approved"] is False
+        assert data["state"] == 8  # Rejected — fail closed, never accepted
+
+    async def test_run_deconfliction_engine_error_fails_closed(self, db):
+        """_run_deconfliction itself must fail closed when plugin loading raises."""
+        start = datetime.now(timezone.utc) + timedelta(hours=1)
+        end = start + timedelta(hours=3)
+        with mock.patch.object(fd_router, "load_plugin", side_effect=RuntimeError("import boom")):
+            is_approved, state = await fd_router._run_deconfliction(
+                geo_json=_geo_json(),
+                start_datetime=start,
+                end_datetime=end,
+                db=db,
+                bounds='{"minx": -122.4, "miny": 37.7, "maxx": -122.3, "maxy": 37.8}',
+            )
+        assert is_approved is False
+        assert state == 8
+
+
+class TestAcceptOnClear:
+    async def test_clear_is_accepted(self, client):
+        with mock.patch.object(fd_router, "_run_deconfliction", return_value=(True, 1)):
+            resp = await client.post(f"{BASE}/set_flight_declaration", json=_payload())
+        assert resp.status_code in (200, 201)
+        data = resp.json()
+        assert data["is_approved"] is True
+        assert data["state"] == 1
+
+    async def test_conflict_is_rejected(self, client):
+        with mock.patch.object(fd_router, "_run_deconfliction", return_value=(False, 8)):
+            resp = await client.post(f"{BASE}/set_flight_declaration", json=_payload())
+        assert resp.status_code in (200, 201)
+        data = resp.json()
+        assert data["is_approved"] is False
+        assert data["state"] == 8
+
+
+class TestEndToEndConflict:
+    """A real second declaration overlapping the first (no engine patch) must be
+    rejected; a disjoint one accepted."""
+
+    async def _create(self, client, coords):
+        start, end = _future_times()
+        payload = {
+            "aircraft_id": "TEST-AIRCRAFT",
+            "originating_party": "Operator",
+            "start_datetime": start,
+            "end_datetime": end,
+            "type_of_operation": 0,
+            "flight_declaration_geo_json": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {"min_altitude": {"meters": 50}, "max_altitude": {"meters": 120}},
+                        "geometry": {"type": "Polygon", "coordinates": [coords]},
+                    }
+                ],
+            },
+        }
+        return await client.post(f"{BASE}/set_flight_declaration", json=payload)
+
+    async def test_overlapping_declaration_rejected(self, client):
+        square_a = [[-122.4, 37.7], [-122.4, 37.8], [-122.3, 37.8], [-122.3, 37.7], [-122.4, 37.7]]
+        overlap = [[-122.35, 37.75], [-122.35, 37.85], [-122.25, 37.85], [-122.25, 37.75], [-122.35, 37.75]]
+        first = await self._create(client, square_a)
+        assert first.json()["state"] == 1  # accepted, becomes active peer
+        second = await self._create(client, overlap)
+        assert second.json()["is_approved"] is False
+        assert second.json()["state"] == 8
+
+    async def test_disjoint_declaration_accepted(self, client):
+        square_a = [[-122.4, 37.7], [-122.4, 37.8], [-122.3, 37.8], [-122.3, 37.7], [-122.4, 37.7]]
+        far = [[-100.0, 30.0], [-100.0, 30.1], [-99.9, 30.1], [-99.9, 30.0], [-100.0, 30.0]]
+        await self._create(client, square_a)
+        second = await self._create(client, far)
+        assert second.json()["is_approved"] is True
+        assert second.json()["state"] == 1

--- a/tests/test_flight_feed_notification.py
+++ b/tests/test_flight_feed_notification.py
@@ -1,0 +1,71 @@
+"""Tests for notification/AMQP dispatch on flight_feed air-traffic ingestion.
+
+The FastAPI migration ships a reusable, ``AMQP_URL``-gated
+``send_operational_update_message`` Celery task (mirroring the Django AMQP
+notification machinery in ``notification_operations``).  The air-traffic
+ingestion endpoints should enqueue that task so downstream consumers learn that
+new observations were ingested.  These tests assert the ingestion endpoints
+enqueue the notification and that the task is a safe no-op when ``AMQP_URL`` is
+unset (no broker connection attempted).
+"""
+
+import uuid
+from unittest import mock
+
+import pytest
+
+OBS_PAYLOAD = {
+    "observations": [
+        {
+            "lat_dd": 1.0,
+            "lon_dd": 2.0,
+            "altitude_mm": 100.0,
+            "traffic_source": 1,
+            "source_type": 0,
+            "icao_address": "abc123",
+        }
+    ]
+}
+
+
+@pytest.mark.anyio
+async def test_set_air_traffic_enqueues_notification(client):
+    session_id = str(uuid.uuid4())
+    with mock.patch("flight_blender.routers.flight_feed.send_operational_update_message") as mock_notify:
+        resp = await client.post(f"/flight_stream/set_air_traffic/{session_id}", json=OBS_PAYLOAD)
+
+    assert resp.status_code == 200
+    mock_notify.delay.assert_called_once()
+    # The session id must be threaded through so the message is operation-scoped.
+    passed = list(mock_notify.delay.call_args.args) + list(mock_notify.delay.call_args.kwargs.values())
+    assert session_id in passed
+
+
+@pytest.mark.anyio
+async def test_bulk_set_air_traffic_enqueues_notification(client):
+    session_id = str(uuid.uuid4())
+    with mock.patch("flight_blender.routers.flight_feed.send_operational_update_message") as mock_notify:
+        resp = await client.post(f"/flight_stream/bulk_set_air_traffic/{session_id}", json=OBS_PAYLOAD)
+
+    assert resp.status_code == 200
+    mock_notify.delay.assert_called_once()
+
+
+def test_notification_task_is_noop_without_amqp_url(monkeypatch):
+    """The notification task must short-circuit (return None, open no connection)
+    when ``AMQP_URL`` is not configured."""
+    import flight_blender.tasks.flight_declaration as fd
+
+    monkeypatch.delenv("AMQP_URL", raising=False)
+
+    # If a broker connection were attempted, this stand-in pika would record it.
+    fake_pika = mock.MagicMock()
+    with mock.patch.dict("sys.modules", {"pika": fake_pika}):
+        # ``.apply`` runs the task eagerly with a properly bound ``self``.
+        outcome = fd.send_operational_update_message.apply(
+            args=("op-1", "1 air traffic observation(s) ingested", "info"),
+        )
+
+    assert outcome.successful()
+    assert outcome.result is None
+    fake_pika.BlockingConnection.assert_not_called()

--- a/tests/test_flight_feed_session_index.py
+++ b/tests/test_flight_feed_session_index.py
@@ -1,0 +1,31 @@
+"""Parity guardrails for the ``flight_feed_observation.session_id`` index.
+
+Django ``flight_feed_operations/models.py`` orders ``FlightObservation`` by
+``-created_at`` and looks observations up by ``session_id`` on the hot
+latest-observation-by-session path.  The FastAPI model/migration must keep an
+index on ``session_id``: the model column must be indexed and a matching Alembic
+migration must create ``ix_flight_feed_observation_session_id``.
+"""
+
+from pathlib import Path
+
+VERSIONS_DIR = Path(__file__).parent.parent / "src" / "flight_blender" / "alembic_migrations" / "versions"
+
+
+def _read_all_migration_sql() -> str:
+    """Concatenate all migration file source into one string for substring checks."""
+    return "\n".join(p.read_text() for p in VERSIONS_DIR.glob("*.py"))
+
+
+def test_session_id_index_migration_exists():
+    """The session_id index must be defined in a migration."""
+    sql = _read_all_migration_sql()
+    assert "ix_flight_feed_observation_session_id" in sql
+
+
+def test_flight_observation_session_id_is_indexed():
+    """The FlightObservation model's session_id column must be indexed."""
+    from flight_blender.models.flight_feed import FlightObservation
+
+    session_col = FlightObservation.__table__.columns["session_id"]
+    assert session_col.index is True

--- a/tests/test_geo_awareness_harness.py
+++ b/tests/test_geo_awareness_harness.py
@@ -1,0 +1,222 @@
+"""Integration tests for the InterUSS geo-awareness test harness endpoints.
+
+Covers (bypass-auth mode, via the shared ``client`` fixture):
+- ``GET /geo_awareness/status`` ED-269 shape
+- ``POST /geo_awareness/map/queries`` present/absent spatial check
+- ``PUT/GET/DELETE /geo_awareness/geospatial_data_sources/{id}`` lifecycle
+
+The ``download_geozone_source`` task is patched by conftest (``.delay`` is a Mock),
+so the PUT path records status without doing real I/O.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from flight_blender.models.geo_fence import GeoFence
+
+BASE = "/geo_fence_ops"
+
+
+async def _add_test_fence(db, *, bounds, geozone=None, is_test=True):
+    now = datetime.now(timezone.utc)
+    fence = GeoFence(
+        raw_geo_fence="{}",
+        geozone=geozone,
+        upper_limit=120.0,
+        lower_limit=0.0,
+        altitude_ref=0,
+        name="Harness Zone",
+        bounds=bounds,
+        status=1,
+        is_test_dataset=is_test,
+        start_datetime=now - timedelta(days=1),
+        end_datetime=now + timedelta(days=365),
+    )
+    db.add(fence)
+    await db.flush()
+    return fence
+
+
+# ── status ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_status_returns_ed269_shape(client):
+    resp = await client.get(f"{BASE}/geo_awareness/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "Ready"
+    assert body["api_version"] == "latest"
+
+
+# ── map/queries spatial check ─────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_map_query_present_when_point_in_zone(client, db):
+    await _add_test_fence(db, bounds="-1.0,51.0,1.0,52.0")
+    body = {"checks": [{"filter_sets": [{"position": {"longitude": 0.0, "latitude": 51.5}}]}]}
+    resp = await client.post(f"{BASE}/geo_awareness/map/queries", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["applicableGeozone"][0]["geozone"] == "Present"
+
+
+@pytest.mark.anyio
+async def test_map_query_absent_when_point_outside_zone(client, db):
+    await _add_test_fence(db, bounds="-1.0,51.0,1.0,52.0")
+    body = {"checks": [{"filter_sets": [{"position": {"longitude": 10.0, "latitude": 10.0}}]}]}
+    resp = await client.post(f"{BASE}/geo_awareness/map/queries", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["applicableGeozone"][0]["geozone"] == "Absent"
+
+
+@pytest.mark.anyio
+async def test_map_query_uses_stored_geometry_ring(client, db):
+    # A triangular zone: point at (0.1, 0.1) is inside, (0.9, 0.9) is outside.
+    feature = {
+        "name": "Triangle",
+        "geometry": [{"horizontalProjection": {"type": "Polygon", "coordinates": [[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]]]}}],
+    }
+    await _add_test_fence(db, bounds="0.0,0.0,1.0,1.0", geozone=json.dumps(feature))
+    inside = await client.post(
+        f"{BASE}/geo_awareness/map/queries",
+        json={"checks": [{"filter_sets": [{"position": {"longitude": 0.1, "latitude": 0.1}}]}]},
+    )
+    assert inside.json()["applicableGeozone"][0]["geozone"] == "Present"
+    outside = await client.post(
+        f"{BASE}/geo_awareness/map/queries",
+        json={"checks": [{"filter_sets": [{"position": {"longitude": 0.9, "latitude": 0.9}}]}]},
+    )
+    # (0.9, 0.9) is inside the bbox but outside the triangle -> ray-cast says Absent.
+    assert outside.json()["applicableGeozone"][0]["geozone"] == "Absent"
+
+
+@pytest.mark.anyio
+async def test_map_query_ignores_non_test_datasets(client, db):
+    await _add_test_fence(db, bounds="-1.0,51.0,1.0,52.0", is_test=False)
+    body = {"checks": [{"filter_sets": [{"position": {"longitude": 0.0, "latitude": 51.5}}]}]}
+    resp = await client.post(f"{BASE}/geo_awareness/map/queries", json=body)
+    assert resp.json()["applicableGeozone"][0]["geozone"] == "Absent"
+
+
+@pytest.mark.anyio
+async def test_map_query_empty_checks_is_absent(client):
+    resp = await client.post(f"{BASE}/geo_awareness/map/queries", json={"checks": []})
+    assert resp.status_code == 200
+    assert resp.json()["applicableGeozone"][0]["geozone"] == "Absent"
+
+
+@pytest.mark.anyio
+async def test_map_query_accepts_interuss_body_shape(client):
+    """The full InterUSS body shape (no ``volumes``) must not 422."""
+    body = {"checks": [{"filter_sets": [{"position": {"uomDimensions": "M", "height": 50, "longitude": 0.0, "latitude": 51.5}}]}]}
+    resp = await client.post(f"{BASE}/geo_awareness/map/queries", json=body)
+    assert resp.status_code == 200
+
+
+# ── geospatial data source lifecycle ───────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_put_source_records_status_and_enqueues(client):
+    source_id = str(uuid.uuid4())
+    from flight_blender.routers import geo_fence as gf_router
+
+    payload = {"https_source": {"url": "https://example.com/zones.json", "format": "ED-269"}}
+    resp = await client.put(f"{BASE}/geo_awareness/geospatial_data_sources/{source_id}", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["result"] == "Activating"
+    # The patched download task was enqueued with the Django kwarg contract.
+    gf_router.download_geozone_source.delay.assert_called_once()
+    _, kwargs = gf_router.download_geozone_source.delay.call_args
+    assert kwargs["geo_zone_url"] == "https://example.com/zones.json"
+    assert kwargs["geozone_source_id"] == source_id
+
+
+@pytest.mark.anyio
+async def test_get_source_returns_stored_status(client):
+    source_id = str(uuid.uuid4())
+    payload = {"https_source": {"url": "https://example.com/zones.json", "format": "ED-269"}}
+    await client.put(f"{BASE}/geo_awareness/geospatial_data_sources/{source_id}", json=payload)
+
+    resp = await client.get(f"{BASE}/geo_awareness/geospatial_data_sources/{source_id}")
+    assert resp.status_code == 200
+    assert resp.json()["result"] == "Activating"
+
+
+@pytest.mark.anyio
+async def test_get_unknown_source_is_404(client):
+    resp = await client.get(f"{BASE}/geo_awareness/geospatial_data_sources/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_delete_known_source_returns_deactivating(client):
+    source_id = str(uuid.uuid4())
+    payload = {"https_source": {"url": "https://example.com/zones.json", "format": "ED-269"}}
+    await client.put(f"{BASE}/geo_awareness/geospatial_data_sources/{source_id}", json=payload)
+
+    resp = await client.delete(f"{BASE}/geo_awareness/geospatial_data_sources/{source_id}")
+    assert resp.status_code == 200
+    assert resp.json()["result"] == "Deactivating"
+
+
+@pytest.mark.anyio
+async def test_delete_unknown_source_is_404(client):
+    resp = await client.delete(f"{BASE}/geo_awareness/geospatial_data_sources/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+# ── set_geozone validation gate ────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_set_geozone_rejects_invalid_payload(client):
+    resp = await client.post(f"{BASE}/set_geozone", json={"foo": "bar"})
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_set_geozone_accepts_valid_payload(client):
+    valid = {
+        "title": "T",
+        "description": "D",
+        "UASZoneList": [{"name": "Z", "geometry": [{"horizontalProjection": {"type": "Circle", "center": [0.0, 51.5], "radius": 100}}]}],
+    }
+    resp = await client.post(f"{BASE}/set_geozone", json=valid)
+    assert resp.status_code == 200, resp.text
+    assert "queued" in resp.json()["message"].lower()
+
+
+# ── list/detail hide test datasets (Django parity) ─────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_excludes_test_datasets(client, db):
+    await _add_test_fence(db, bounds="0,0,1,1", is_test=True)
+    await _add_test_fence(db, bounds="0,0,1,1", is_test=False)
+    resp = await client.get(f"{BASE}/geo_fence")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 1
+    assert all(not r["is_test_dataset"] for r in body["results"])
+
+
+@pytest.mark.anyio
+async def test_detail_hides_test_dataset(client, db):
+    fence = await _add_test_fence(db, bounds="0,0,1,1", is_test=True)
+    resp = await client.get(f"{BASE}/geo_fence/{fence.id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_detail_returns_operational_fence(client, db):
+    fence = await _add_test_fence(db, bounds="0,0,1,1", is_test=False)
+    resp = await client.get(f"{BASE}/geo_fence/{fence.id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(fence.id)

--- a/tests/test_geo_awareness_scope.py
+++ b/tests/test_geo_awareness_scope.py
@@ -1,0 +1,100 @@
+"""Tests that geo-awareness endpoints enforce the dedicated geo-awareness.test scope.
+
+These exercise the real scope-checking path (``require_scope``) by replacing the
+token-verification chokepoint (``verify_bearer_token``) with a stub that returns a
+chosen set of scopes, rather than relying on the bypass flag (which grants all
+scopes).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import flight_blender.auth.jwt_bearer as jwt_bearer
+
+BASE = "/geo_fence_ops"
+
+
+def _patch_scopes(monkeypatch, scopes):
+    """Force ``verify_bearer_token`` to return the given scopes for any token."""
+    monkeypatch.setattr(
+        jwt_bearer,
+        "verify_bearer_token",
+        lambda token: {"scope": " ".join(scopes)},
+    )
+
+
+@pytest.mark.anyio
+async def test_geo_awareness_status_scope_enforced(client, monkeypatch):
+    _patch_scopes(monkeypatch, ["blender.read", "blender.write"])
+    resp = await client.get(
+        f"{BASE}/geo_awareness/status",
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_geo_awareness_status_allows_with_scope(client, monkeypatch):
+    _patch_scopes(monkeypatch, ["geo-awareness.test"])
+    resp = await client.get(
+        f"{BASE}/geo_awareness/status",
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "Ready"
+
+
+@pytest.mark.anyio
+async def test_put_geozone_source_scope_enforced(client, monkeypatch):
+    _patch_scopes(monkeypatch, ["blender.write"])
+    resp = await client.put(
+        f"{BASE}/geo_awareness/geospatial_data_sources/src1",
+        json={"https_source": {"url": "https://example.com/z.json", "format": "ED-269"}},
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_get_geozone_source_scope_enforced(client, monkeypatch):
+    _patch_scopes(monkeypatch, ["blender.read"])
+    resp = await client.get(
+        f"{BASE}/geo_awareness/geospatial_data_sources/src1",
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_delete_geozone_source_scope_enforced(client, monkeypatch):
+    _patch_scopes(monkeypatch, ["blender.write"])
+    resp = await client.delete(
+        f"{BASE}/geo_awareness/geospatial_data_sources/src1",
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_query_geozone_scope_enforced(client, monkeypatch):
+    _patch_scopes(monkeypatch, ["blender.read"])
+    resp = await client.post(
+        f"{BASE}/geo_awareness/map/queries",
+        json={"checks": []},
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_query_geozone_allows_with_scope(client, monkeypatch):
+    _patch_scopes(monkeypatch, ["geo-awareness.test"])
+    resp = await client.post(
+        f"{BASE}/geo_awareness/map/queries",
+        json={"checks": []},
+        headers={"Authorization": "Bearer faketoken"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "applicableGeozone" in body

--- a/tests/test_geo_zone_parsing.py
+++ b/tests/test_geo_zone_parsing.py
@@ -1,0 +1,144 @@
+"""Unit tests for the GeoZone parsing pipeline (Django ``write_geo_zone`` parity).
+
+Covers the pure-Python parsing helpers (no shapely):
+- ED-269 ``upperLimit`` / ``lowerLimit`` field names
+- Circle -> polygon ring buffering
+- real bounding-box computation (comma-separated string)
+- raw_geo_fence / geozone persistence fields and is_test_dataset flagging
+- the request-time ``validate_geo_zone`` gate
+"""
+
+from __future__ import annotations
+
+import json
+
+from flight_blender.tasks.geo_fence import (
+    compute_bounds,
+    feature_to_coordinates,
+    geodesic_circle_to_ring,
+    parse_geo_zone_features,
+    validate_geo_zone,
+)
+
+# A minimal ED-269 GeoZone with a Circle geometry.
+CIRCLE_GEO_ZONE = {
+    "title": "Test Zone",
+    "description": "A test geozone",
+    "UASZoneList": [
+        {
+            "identifier": "ZONE-1",
+            "name": "Restricted Alpha",
+            "upperLimit": 120,
+            "lowerLimit": 0,
+            "zoneAuthority": [{"name": "CAA"}],
+            "applicability": {
+                "startDateTime": "2023-01-01T00:00:00Z",
+                "endDateTime": "2030-01-01T00:00:00Z",
+            },
+            "geometry": [{"horizontalProjection": {"type": "Circle", "center": [0.0, 51.5], "radius": 500}}],
+        }
+    ],
+}
+
+POLYGON_GEO_ZONE = {
+    "title": "Poly Zone",
+    "description": "Polygon geozone",
+    "features": [
+        {
+            "name": "Poly Alpha",
+            "upperLimit": 300,
+            "lowerLimit": 50,
+            "geometry": [
+                {
+                    "horizontalProjection": {
+                        "type": "Polygon",
+                        "coordinates": [[[0.0, 51.0], [1.0, 51.0], [1.0, 52.0], [0.0, 52.0], [0.0, 51.0]]],
+                    }
+                }
+            ],
+        }
+    ],
+}
+
+
+def test_geodesic_circle_to_ring_is_closed_ring_around_center():
+    ring = geodesic_circle_to_ring(0.0, 51.5, 500)
+    assert len(ring) >= 4
+    assert ring[0] == ring[-1]  # closed
+    # All points should be near the center (within ~0.01 deg for a 500 m radius).
+    for lon, lat in ring:
+        assert abs(lon - 0.0) < 0.02
+        assert abs(lat - 51.5) < 0.02
+
+
+def test_feature_to_coordinates_circle_buffers_to_ring():
+    coords = feature_to_coordinates(CIRCLE_GEO_ZONE["UASZoneList"][0])
+    assert len(coords) >= 4
+    # Center should sit inside the bbox of the buffered ring.
+    lons = [c[0] for c in coords]
+    lats = [c[1] for c in coords]
+    assert min(lons) < 0.0 < max(lons)
+    assert min(lats) < 51.5 < max(lats)
+
+
+def test_feature_to_coordinates_polygon():
+    coords = feature_to_coordinates(POLYGON_GEO_ZONE["features"][0])
+    assert [0.0, 51.0] in coords
+    assert [1.0, 52.0] in coords
+
+
+def test_compute_bounds_format_is_comma_separated_minx_miny_maxx_maxy():
+    bounds = compute_bounds([[0.0, 51.0], [1.0, 52.0]])
+    parts = bounds.split(",")
+    assert len(parts) == 4
+    minx, miny, maxx, maxy = (float(p) for p in parts)
+    assert (minx, miny, maxx, maxy) == (0.0, 51.0, 1.0, 52.0)
+
+
+def test_compute_bounds_empty_returns_empty_string():
+    assert compute_bounds([]) == ""
+
+
+def test_parse_geo_zone_features_reads_ed269_limits_and_sets_fields():
+    parsed = parse_geo_zone_features(CIRCLE_GEO_ZONE)
+    assert len(parsed) == 1
+    feat = parsed[0]
+    # ED-269 upperLimit / lowerLimit (NOT upper_limit_m / lower_limit_m).
+    assert feat["upper_limit"] == 120.0
+    assert feat["lower_limit"] == 0.0
+    assert feat["name"] == "Restricted Alpha"
+    # Real bounds were computed (non-empty, comma-separated).
+    assert feat["bounds"] and len(feat["bounds"].split(",")) == 4
+    # raw_geo_fence holds the whole document; geozone holds the feature.
+    assert json.loads(feat["raw_geo_fence"])["title"] == "Test Zone"
+    assert json.loads(feat["geozone"])["identifier"] == "ZONE-1"
+    # GeoZone ingest feeds the test harness -> flagged as test dataset.
+    assert feat["is_test_dataset"] is True
+    assert feat["status"] == 1
+
+
+def test_parse_geo_zone_features_polygon_limits():
+    parsed = parse_geo_zone_features(POLYGON_GEO_ZONE)
+    assert parsed[0]["upper_limit"] == 300.0
+    assert parsed[0]["lower_limit"] == 50.0
+
+
+# ── validate_geo_zone gate ──────────────────────────────────────────────────────
+
+
+def test_validate_geo_zone_accepts_valid_payload():
+    assert validate_geo_zone(CIRCLE_GEO_ZONE) is True
+    assert validate_geo_zone(POLYGON_GEO_ZONE) is True
+
+
+def test_validate_geo_zone_rejects_empty_features():
+    assert validate_geo_zone({"title": "x", "description": "y", "UASZoneList": []}) is False
+
+
+def test_validate_geo_zone_rejects_non_dict():
+    assert validate_geo_zone("not a dict") is False
+    assert validate_geo_zone(123) is False
+
+
+def test_validate_geo_zone_accepts_json_string():
+    assert validate_geo_zone(json.dumps(CIRCLE_GEO_ZONE)) is True

--- a/tests/test_notification_persistence.py
+++ b/tests/test_notification_persistence.py
@@ -1,0 +1,102 @@
+"""Tests for the operator-RID notification persistence path (FastAPI port).
+
+Mirrors the Django ``OperatorRIDNotificationCreator`` / ``operator_rid_notifications``
+consumer behaviour: published operator-RID notifications are persisted as
+``OperatorRIDNotification`` rows.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+from sqlalchemy import select
+
+from flight_blender.models.notification import OperatorRIDNotification
+from flight_blender.tasks import notification as nt
+
+
+@pytest.mark.anyio
+async def test_create_operator_rid_notification_persists_row(db):
+    """The creator writes an OperatorRIDNotification row with the Django field mapping."""
+    created = await nt.create_operator_rid_notification(
+        message="hello operator",
+        session_id="sess-abc",
+        db=db,
+    )
+
+    assert created.id is not None
+    assert created.message == "hello operator"
+    assert created.session_id == "sess-abc"
+    # Django default: is_active=True.
+    assert created.is_active is True
+
+    rows = (await db.execute(select(OperatorRIDNotification))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].message == "hello operator"
+    assert rows[0].session_id == "sess-abc"
+
+
+@pytest.mark.anyio
+async def test_create_operator_rid_notification_serialises_dict_message(db):
+    """A dict message (as delivered over AMQP) is serialised to JSON text."""
+    payload = {"event": "rid", "value": 42}
+    created = await nt.create_operator_rid_notification(
+        message=payload,
+        session_id="sess-dict",
+        db=db,
+    )
+
+    assert json.loads(created.message) == payload
+    assert created.session_id == "sess-dict"
+
+
+@pytest.mark.anyio
+async def test_create_operator_rid_notification_allows_null_session(db):
+    """session_id is nullable (Django blank/null=True)."""
+    created = await nt.create_operator_rid_notification(
+        message="no session",
+        session_id=None,
+        db=db,
+    )
+    assert created.session_id is None
+    assert created.message == "no session"
+
+
+def test_consume_operator_rid_notifications_is_noop_without_amqp(monkeypatch):
+    """The consumer entrypoint is import-safe and a no-op without AMQP_URL."""
+    monkeypatch.delenv("AMQP_URL", raising=False)
+
+    fake_pika = mock.MagicMock()
+    with mock.patch.dict("sys.modules", {"pika": fake_pika}):
+        # Must not raise and must not attempt a broker connection.
+        nt.consume_operator_rid_notifications()
+
+    fake_pika.BlockingConnection.assert_not_called()
+
+
+def test_send_operational_update_persists_when_no_amqp(monkeypatch):
+    """P2: without AMQP_URL the notification is persisted locally, not silently dropped."""
+    monkeypatch.delenv("AMQP_URL", raising=False)
+
+    captured: dict = {}
+
+    # Capture the local-persistence call the task makes when AMQP is unset.
+    monkeypatch.setattr(
+        nt,
+        "_persist_operator_rid_notification_sync",
+        lambda **kw: captured.update(kw),
+    )
+
+    import flight_blender.tasks.flight_declaration as fd
+
+    outcome = fd.send_operational_update_message.apply(
+        args=("op-77", "feed update", "info"),
+    )
+
+    assert outcome.successful()
+    # The session id (operation id) and message must be threaded through to the
+    # local persistence path instead of being dropped.
+    assert captured.get("session_id") == "op-77"
+    assert captured.get("message") == "feed update"

--- a/tests/test_peer_uss_client.py
+++ b/tests/test_peer_uss_client.py
@@ -1,0 +1,266 @@
+"""Tests for the peer-USS / DSS op-intent client (HTTP layer mocked).
+
+These tests exercise request construction (URL, auth header, body) and response
+parsing for the peer-USS op-intent details GET, the peer notification POST, and
+the OVN/key/extents builder used for DSS op-intent reference writes.
+
+The raw network round-trip is never performed: the module-level ``requests``
+import is patched and ``_auth_header`` is stubbed, so only the testable client
+logic runs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flight_blender.schemas.deconfliction import (
+    OperationalIntentReference,
+    PeerOperationalIntentDetails,
+)
+from flight_blender.services import peer_uss_client
+
+
+@pytest.fixture(autouse=True)
+def _stub_auth(monkeypatch):
+    """Avoid real DSS token retrieval; return a deterministic auth header."""
+    monkeypatch.setattr(
+        peer_uss_client,
+        "_auth_header",
+        lambda *a, **k: {"Authorization": "Bearer test-token", "Content-Type": "application/json"},
+    )
+
+
+# ── P1: peer op-intent details GET ───────────────────────────────────────────
+@pytest.mark.anyio
+async def test_get_peer_details_builds_request_and_parses_volumes():
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {
+        "operational_intent": {
+            "details": {
+                "volumes": [
+                    {
+                        "volume": {
+                            "outline_polygon": {
+                                "vertices": [
+                                    {"lat": 1.0, "lng": 2.0},
+                                    {"lat": 3.0, "lng": 4.0},
+                                ]
+                            },
+                            "altitude_lower": {"value": 10.0},
+                            "altitude_upper": {"value": 120.0},
+                        },
+                        "time_start": {"value": "2026-01-01T00:00:00Z"},
+                        "time_end": {"value": "2026-01-01T01:00:00Z"},
+                    }
+                ]
+            }
+        }
+    }
+    captured = {}
+
+    def fake_get(url, headers, timeout):  # noqa: ANN001, ANN202
+        captured["url"] = url
+        captured["headers"] = headers
+        return fake_response
+
+    reference = OperationalIntentReference(id="op-123", uss_base_url="https://peer.example.com")
+    with patch.object(peer_uss_client, "requests") as mock_requests:
+        mock_requests.get.side_effect = fake_get
+        mock_requests.RequestException = Exception
+        result = peer_uss_client.get_peer_operational_intent_details(reference)
+
+    assert isinstance(result, PeerOperationalIntentDetails)
+    assert captured["url"] == "https://peer.example.com/uss/v1/operational_intents/op-123"
+    assert captured["headers"]["Authorization"] == "Bearer test-token"
+    assert len(result.volumes) == 1
+    volume = result.volumes[0]
+    assert volume.altitude_lower == 10.0
+    assert volume.altitude_upper == 120.0
+    assert len(volume.outline_polygon) == 2
+    assert volume.outline_polygon[0].lat == 1.0
+    assert result.reference is reference
+
+
+@pytest.mark.anyio
+async def test_get_peer_details_non_200_returns_empty():
+    fake_response = MagicMock()
+    fake_response.status_code = 404
+
+    reference = OperationalIntentReference(id="missing", uss_base_url="https://peer.example.com")
+    with patch.object(peer_uss_client, "requests") as mock_requests:
+        mock_requests.get.return_value = fake_response
+        mock_requests.RequestException = Exception
+        result = peer_uss_client.get_peer_operational_intent_details(reference)
+
+    assert isinstance(result, PeerOperationalIntentDetails)
+    assert result.volumes == []
+
+
+@pytest.mark.anyio
+async def test_get_peer_details_network_error_returns_empty():
+    reference = OperationalIntentReference(id="op-err", uss_base_url="https://peer.example.com")
+    with patch.object(peer_uss_client, "requests") as mock_requests:
+        mock_requests.RequestException = Exception
+        mock_requests.get.side_effect = Exception("boom")
+        result = peer_uss_client.get_peer_operational_intent_details(reference)
+
+    assert isinstance(result, PeerOperationalIntentDetails)
+    assert result.volumes == []
+
+
+@pytest.mark.anyio
+async def test_get_peer_details_missing_base_url_returns_empty():
+    reference = OperationalIntentReference(id="op-1", uss_base_url=None)
+    result = peer_uss_client.get_peer_operational_intent_details(reference)
+    assert isinstance(result, PeerOperationalIntentDetails)
+    assert result.volumes == []
+
+
+@pytest.mark.anyio
+async def test_get_peer_details_malformed_body_returns_empty():
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"unexpected": "shape"}
+
+    reference = OperationalIntentReference(id="op-2", uss_base_url="https://peer.example.com")
+    with patch.object(peer_uss_client, "requests") as mock_requests:
+        mock_requests.get.return_value = fake_response
+        mock_requests.RequestException = Exception
+        result = peer_uss_client.get_peer_operational_intent_details(reference)
+
+    assert result.volumes == []
+    assert result.reference is reference
+
+
+# ── P2: OVN / key / extents builder ──────────────────────────────────────────
+def test_collect_ovns_from_references():
+    references = [
+        {"id": "a", "ovn": "ovn-a"},
+        {"id": "b", "ovn": "ovn-b"},
+        {"id": "c"},  # no OVN — skipped
+        {"id": "d", "ovn": None},  # null OVN — skipped
+    ]
+    assert peer_uss_client.collect_ovns(references) == ["ovn-a", "ovn-b"]
+
+
+def test_build_op_intent_reference_payload_has_key_and_extents():
+    volumes = [{"volume": {"foo": "bar"}}]
+    references = [{"id": "a", "ovn": "ovn-a"}, {"id": "b", "ovn": "ovn-b"}]
+    payload = peer_uss_client.build_operational_intent_reference_payload(
+        volumes=volumes,
+        state="Accepted",
+        existing_references=references,
+        uss_base_url="https://blender.example.com",
+    )
+    assert payload["extents"] == volumes
+    assert payload["key"] == ["ovn-a", "ovn-b"]
+    assert payload["state"] == "Accepted"
+    assert payload["uss_base_url"] == "https://blender.example.com"
+    assert payload["new_subscription"]["uss_base_url"] == "https://blender.example.com"
+    assert payload["new_subscription"]["notify_for_constraints"] is False
+
+
+def test_build_op_intent_reference_payload_empty_references_gives_empty_key():
+    volumes = [{"volume": {"foo": "bar"}}]
+    payload = peer_uss_client.build_operational_intent_reference_payload(
+        volumes=volumes,
+        state="Accepted",
+        existing_references=[],
+        uss_base_url="https://blender.example.com",
+    )
+    assert payload["key"] == []
+    assert payload["extents"] == volumes
+
+
+def test_build_op_intent_reference_payload_extents_never_empty_when_volumes_present():
+    volumes = [{"volume": {"a": 1}}, {"volume": {"b": 2}}]
+    payload = peer_uss_client.build_operational_intent_reference_payload(
+        volumes=volumes,
+        state="Activated",
+        existing_references=[{"id": "x", "ovn": "ovn-x"}],
+        uss_base_url="https://blender.example.com",
+    )
+    assert payload["extents"]  # non-empty
+    assert payload["extents"] == volumes
+
+
+# ── P3: peer notification POST builder + gate ────────────────────────────────
+def test_build_peer_notification_payload_shape():
+    payload = peer_uss_client.build_peer_notification_payload(
+        operational_intent_id="op-9",
+        operational_intent_details={"volumes": [{"v": 1}]},
+        ovn="ovn-9",
+        blender_base_url="https://blender.example.com",
+        subscriptions=[{"subscription_id": "s1"}],
+    )
+    assert payload["operational_intent_id"] == "op-9"
+    reference = payload["operational_intent"]["reference"]
+    assert reference["id"] == "op-9"
+    assert reference["ovn"] == "ovn-9"
+    assert reference["uss_base_url"] == "https://blender.example.com"
+    assert payload["operational_intent"]["details"] == {"volumes": [{"v": 1}]}
+    assert payload["subscriptions"] == [{"subscription_id": "s1"}]
+
+
+@pytest.mark.anyio
+async def test_notify_peer_uss_builds_request_and_returns_true_on_204(monkeypatch):
+    monkeypatch.setattr(peer_uss_client.settings, "ussp_network_enabled", True)
+    fake_response = MagicMock()
+    fake_response.status_code = 204
+    captured = {}
+
+    def fake_post(url, json, headers, timeout):  # noqa: ANN001, ANN202
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        return fake_response
+
+    payload = {"operational_intent_id": "op-1", "subscriptions": []}
+    with patch.object(peer_uss_client, "requests") as mock_requests:
+        mock_requests.post.side_effect = fake_post
+        mock_requests.RequestException = Exception
+        result = peer_uss_client.notify_peer_uss("https://peer.example.com", payload)
+
+    assert result is True
+    assert captured["url"] == "https://peer.example.com/uss/v1/operational_intents"
+    assert captured["json"] == payload
+    assert captured["headers"]["Authorization"] == "Bearer test-token"
+
+
+@pytest.mark.anyio
+async def test_notify_peer_uss_non_204_returns_false(monkeypatch):
+    monkeypatch.setattr(peer_uss_client.settings, "ussp_network_enabled", True)
+    fake_response = MagicMock()
+    fake_response.status_code = 400
+
+    with patch.object(peer_uss_client, "requests") as mock_requests:
+        mock_requests.post.return_value = fake_response
+        mock_requests.RequestException = Exception
+        result = peer_uss_client.notify_peer_uss("https://peer.example.com", {"subscriptions": []})
+
+    assert result is False
+
+
+@pytest.mark.anyio
+async def test_notify_peer_uss_gated_when_network_disabled(monkeypatch):
+    monkeypatch.setattr(peer_uss_client.settings, "ussp_network_enabled", False)
+    with patch.object(peer_uss_client, "requests") as mock_requests:
+        mock_requests.RequestException = Exception
+        result = peer_uss_client.notify_peer_uss("https://peer.example.com", {"subscriptions": []})
+
+    assert result is False
+    mock_requests.post.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_notify_peer_uss_network_error_returns_false(monkeypatch):
+    monkeypatch.setattr(peer_uss_client.settings, "ussp_network_enabled", True)
+    with patch.object(peer_uss_client, "requests") as mock_requests:
+        mock_requests.RequestException = Exception
+        mock_requests.post.side_effect = Exception("boom")
+        result = peer_uss_client.notify_peer_uss("https://peer.example.com", {"subscriptions": []})
+
+    assert result is False

--- a/tests/test_rid_flight_detail.py
+++ b/tests/test_rid_flight_detail.py
@@ -1,0 +1,60 @@
+"""RID flight-detail create -> persist -> read parity tests (P3).
+
+Django persists ``RIDFlightDetail`` rows (operator id/location, auth data,
+UAS id, EU classification, operation description) and serves them back over the
+peer-USS RID exchange (``get_uss_flight_details`` -> ``{"details": {...}}``).
+The FastAPI port previously returned canned data and persisted nothing for the
+detail-by-id path.
+
+These tests pin a real round-trip: create a flight detail (persisted to the
+SQLAlchemy ``RIDFlightDetail`` model), then read it back via the
+Django-compatible peer-USS endpoint ``GET /uss/flights/<id>/details``.
+"""
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_create_flight_detail_persists_and_reads_back(client):
+    payload = {
+        "operation_description": "Aerial survey",
+        "operator_id": "OP-123",
+        "operator_location": {"position": {"lat": 51.5, "lng": -0.1}},
+        "auth_data": {"format": 0, "data": ""},
+        "uas_id": {"serial_number": "SN-1", "registration_id": "REG-1"},
+        "eu_classification": {"category": "Open", "class": "C0"},
+    }
+    create = await client.post("/rid/flight_details", json=payload)
+    assert create.status_code == 201
+    body = create.json()
+    detail_id = body["id"]
+    assert body["operator_id"] == "OP-123"
+    assert body["operation_description"] == "Aerial survey"
+
+    # Read back via the Django-compatible peer-USS RID endpoint.
+    read = await client.get(f"/uss/flights/{detail_id}/details")
+    assert read.status_code == 200
+    details = read.json()["details"]
+    assert details["id"] == detail_id
+    assert details["operator_id"] == "OP-123"
+    # JSON fields round-trip back into structured objects (not raw strings).
+    assert details["operator_location"] == {"position": {"lat": 51.5, "lng": -0.1}}
+    assert details["uas_id"]["serial_number"] == "SN-1"
+
+
+async def test_read_unknown_flight_detail_404(client):
+    read = await client.get(f"/uss/flights/{uuid.uuid4()}/details")
+    assert read.status_code == 404
+
+
+async def test_create_flight_detail_minimal(client):
+    """A near-empty detail still persists and reads back with at least its id."""
+    create = await client.post("/rid/flight_details", json={"operator_id": "OP-MIN"})
+    assert create.status_code == 201
+    detail_id = create.json()["id"]
+    read = await client.get(f"/uss/flights/{detail_id}/details")
+    assert read.status_code == 200
+    assert read.json()["details"]["operator_id"] == "OP-MIN"

--- a/tests/test_rid_model_parity.py
+++ b/tests/test_rid_model_parity.py
@@ -1,0 +1,33 @@
+"""Schema-parity checks for the RID models vs the Django originals (P4).
+
+Django (``rid_operations/models.py``):
+  * ``ISASubscription.view_hash``       -> ``IntegerField(null=True, db_index=True)``
+  * ``ISASubscription.subscription_id`` -> ``db_index=True``
+  * ``ISASubscription.created_at``      -> ``db_index=True``
+  * ``RIDFlightDetail.created_at``      -> ``db_index=True``
+
+The FastAPI port computes a *string* view hash, so we keep ``view_hash`` a
+``String`` (documented deviation) but make it nullable to match Django's
+``null=True``. The ``db_index=True`` columns must carry indexes.
+"""
+
+from flight_blender.models.rid import ISASubscription, RIDFlightDetail
+
+
+def _col(model, name):
+    return model.__table__.columns[name]
+
+
+def test_view_hash_is_nullable():
+    # Django: IntegerField(null=True). We keep String (FastAPI computes a string
+    # hash) but it must be nullable.
+    assert _col(ISASubscription, "view_hash").nullable is True
+
+
+def test_indexed_columns_present():
+    cols = ISASubscription.__table__.columns
+    detail_cols = RIDFlightDetail.__table__.columns
+    assert cols["subscription_id"].index is True
+    assert cols["view_hash"].index is True
+    assert cols["created_at"].index is True
+    assert detail_cols["created_at"].index is True

--- a/tests/test_scd_strategic.py
+++ b/tests/test_scd_strategic.py
@@ -1,0 +1,131 @@
+"""
+Tests for the SCD strategic conflict computation in the flight-planning router.
+
+These assert the ASTM *planning_result* produced by the deconfliction engine
+against declarations stored in the DB — no live DSS / network involved.
+
+Behaviour mirrors the Django ``upsert_close_flight_plan``:
+* usage_state not Planned/InUse, or no volumes supplied -> "NotPlanned".
+* Planned/InUse with volumes, clear            -> "Planned".
+* Planned/InUse with volumes, conflict          -> "ConflictWithFlight".
+"""
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from flight_blender.models.flight_declaration import FlightDeclaration
+
+pytestmark = pytest.mark.anyio
+
+BASE = "/scd"
+
+_SQUARE_A = [[-122.4, 37.7], [-122.4, 37.8], [-122.3, 37.8], [-122.3, 37.7], [-122.4, 37.7]]
+_SQUARE_OVERLAP = [[-122.35, 37.75], [-122.35, 37.85], [-122.25, 37.85], [-122.25, 37.75], [-122.35, 37.75]]
+_SQUARE_FAR = [[-100.0, 30.0], [-100.0, 30.1], [-99.9, 30.1], [-99.9, 30.0], [-100.0, 30.0]]
+
+
+def _times():
+    start = datetime.now(timezone.utc) + timedelta(hours=1)
+    end = start + timedelta(hours=2)
+    return start, end
+
+
+def _intended_flight(coords, usage_state="Planned"):
+    start, end = _times()
+    return {
+        "intended_flight": {
+            "basic_information": {"usage_state": usage_state, "uas_state": "Nominal"},
+            "operational_intent": {
+                "volumes": [
+                    {
+                        "volume": {
+                            "outline_polygon": {"vertices": [{"lng": c[0], "lat": c[1]} for c in coords]},
+                            "altitude_lower": {"value": 50},
+                            "altitude_upper": {"value": 120},
+                        },
+                        "time_start": {"value": start.isoformat()},
+                        "time_end": {"value": end.isoformat()},
+                    }
+                ],
+                "off_nominal_volumes": [],
+                "priority": 0,
+            },
+        },
+        "usage_state": usage_state,
+        "uas_state": "Nominal",
+    }
+
+
+def _geojson(coords):
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"min_altitude": {"meters": 50}, "max_altitude": {"meters": 120}},
+                "geometry": {"type": "Polygon", "coordinates": [coords]},
+            }
+        ],
+    }
+
+
+async def _seed_declaration(db, coords):
+    start, end = _times()
+    decl = FlightDeclaration(
+        operational_intent="{}",
+        flight_declaration_raw_geojson=json.dumps(_geojson(coords)),
+        bounds=json.dumps(
+            {
+                "minx": min(c[0] for c in coords),
+                "miny": min(c[1] for c in coords),
+                "maxx": max(c[0] for c in coords),
+                "maxy": max(c[1] for c in coords),
+            }
+        ),
+        aircraft_id="peer",
+        type_of_operation=0,
+        state=1,  # Accepted / active
+        originating_party="peer",
+        start_datetime=start,
+        end_datetime=end,
+    )
+    db.add(decl)
+    await db.commit()
+
+
+class TestStrategicResult:
+    async def test_not_planned_when_not_planned_usage_state(self, client):
+        plan_id = str(uuid.uuid4())
+        resp = await client.put(f"{BASE}/flight_planning/flight_plans/{plan_id}", json=_intended_flight(_SQUARE_A, usage_state="Closed"))
+        assert resp.status_code == 200
+        assert resp.json()["planning_result"] == "NotPlanned"
+
+    async def test_planned_when_no_existing(self, client):
+        plan_id = str(uuid.uuid4())
+        resp = await client.put(f"{BASE}/flight_planning/flight_plans/{plan_id}", json=_intended_flight(_SQUARE_A))
+        assert resp.status_code == 200
+        assert resp.json()["planning_result"] == "Planned"
+
+    async def test_planned_when_disjoint(self, client, db):
+        await _seed_declaration(db, _SQUARE_FAR)
+        plan_id = str(uuid.uuid4())
+        resp = await client.put(f"{BASE}/flight_planning/flight_plans/{plan_id}", json=_intended_flight(_SQUARE_A))
+        assert resp.status_code == 200
+        assert resp.json()["planning_result"] == "Planned"
+
+    async def test_conflict_when_overlapping(self, client, db):
+        await _seed_declaration(db, _SQUARE_OVERLAP)
+        plan_id = str(uuid.uuid4())
+        resp = await client.put(f"{BASE}/flight_planning/flight_plans/{plan_id}", json=_intended_flight(_SQUARE_A))
+        assert resp.status_code == 200
+        assert resp.json()["planning_result"] == "ConflictWithFlight"
+
+    async def test_uspace_variant_conflict(self, client, db):
+        await _seed_declaration(db, _SQUARE_OVERLAP)
+        plan_id = str(uuid.uuid4())
+        resp = await client.put(f"{BASE}/flight_planning/u_space/flight_plans/{plan_id}", json=_intended_flight(_SQUARE_A))
+        assert resp.status_code == 200
+        assert resp.json()["planning_result"] == "ConflictWithFlight"

--- a/tests/test_state_invariants.py
+++ b/tests/test_state_invariants.py
@@ -1,0 +1,47 @@
+"""
+Shared operational-intent state invariants.
+
+Restores the load-bearing state groupings from the Django
+``common/data_definitions.py`` (dropped in the FastAPI migration) so that
+conformance / flight-declaration / SCD logic share one typed source of truth.
+These tests pin the exact integer state sets from the Django original.
+"""
+
+from flight_blender.common.enums import (
+    ACTIVE_OPERATIONAL_STATES,
+    VALID_OPERATIONAL_INTENT_STATES,
+    OperationState,
+)
+
+
+def test_valid_operational_intent_states():
+    """Op-intent states valid for coordination (Django [1, 2, 3, 4])."""
+    assert VALID_OPERATIONAL_INTENT_STATES == frozenset(
+        {
+            OperationState.ACCEPTED,
+            OperationState.ACTIVATED,
+            OperationState.NONCONFORMING,
+            OperationState.CONTINGENT,
+        }
+    )
+
+
+def test_active_operational_states():
+    """States where the operation is actively airborne (Django [2, 3, 4])."""
+    assert ACTIVE_OPERATIONAL_STATES == frozenset(
+        {
+            OperationState.ACTIVATED,
+            OperationState.NONCONFORMING,
+            OperationState.CONTINGENT,
+        }
+    )
+
+
+def test_active_states_are_subset_of_valid_states():
+    assert ACTIVE_OPERATIONAL_STATES <= VALID_OPERATIONAL_INTENT_STATES
+
+
+def test_state_sets_use_integer_values():
+    """The frozensets compare equal to the raw Django integer lists."""
+    assert {int(s) for s in VALID_OPERATIONAL_INTENT_STATES} == {1, 2, 3, 4}
+    assert {int(s) for s in ACTIVE_OPERATIONAL_STATES} == {2, 3, 4}

--- a/tests/test_surveillance_heartbeat_metrics.py
+++ b/tests/test_surveillance_heartbeat_metrics.py
@@ -1,0 +1,106 @@
+"""
+Unit tests for the pure SDSP heartbeat metrics computation and the
+``GET /surveillance_monitoring_ops/get_air_traffic`` endpoint.
+
+These cover the two behavioural regressions restored from the Django original:
+
+* ``compute_sdsp_heartbeat`` derives latency / accuracy / SLA booleans from the
+  live observation stream instead of returning hard-coded "healthy" constants.
+* ``get_air_traffic`` re-exposes the latest observations (read from Redis) for
+  display, matching the Django ``get_air_traffic`` GET view.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from flight_blender.tasks.surveillance import compute_sdsp_heartbeat
+
+BASE = "/surveillance_monitoring_ops"
+
+
+def _obs(seconds_ago: float, hacc: float = 3.0, vacc: float = 3.0) -> dict:
+    """Build one observation dict whose ``timestamp`` is ``seconds_ago`` in the past."""
+    now = datetime.now(tz=timezone.utc)
+    ts = now - timedelta(seconds=seconds_ago)
+    return {
+        "timestamp": ts.isoformat(),
+        "horizontal_accuracy_m": str(hacc),
+        "vertical_accuracy_m": str(vacc),
+    }
+
+
+# ── compute_sdsp_heartbeat (pure) ───────────────────────────────────────────────
+
+
+def test_compute_sdsp_heartbeat_empty_stream_is_degraded():
+    """No observations => SLA booleans False and sentinel latency/accuracy."""
+    result = compute_sdsp_heartbeat([])
+    assert result["meets_sla_surveillance_requirements"] is False
+    assert result["meets_sla_rr_lr_requirements"] is False
+    # No data: latency/accuracy must not falsely report a healthy value.
+    assert result["average_latency_or_95_percentile_latency_ms"] is None
+    assert result["horizontal_or_vertical_95_percentile_accuracy_m"] is None
+    assert "surveillance_sdsp_name" in result
+    assert "timestamp" in result
+
+
+def test_compute_sdsp_heartbeat_healthy_stream_within_sla():
+    """Fresh, accurate observations => both SLA booleans True, low latency."""
+    now = datetime.now(tz=timezone.utc)
+    observations = [_obs(0.05, hacc=2.0, vacc=2.0), _obs(0.10, hacc=3.0, vacc=3.0)]
+    result = compute_sdsp_heartbeat(observations, now=now)
+    assert result["meets_sla_surveillance_requirements"] is True
+    assert result["meets_sla_rr_lr_requirements"] is True
+    assert result["average_latency_or_95_percentile_latency_ms"] is not None
+    assert result["average_latency_or_95_percentile_latency_ms"] < 1000
+    assert result["horizontal_or_vertical_95_percentile_accuracy_m"] is not None
+    assert result["horizontal_or_vertical_95_percentile_accuracy_m"] <= 10.0
+
+
+def test_compute_sdsp_heartbeat_stale_stream_breaks_sla():
+    """Old observations (high latency) => surveillance SLA False."""
+    now = datetime.now(tz=timezone.utc)
+    # 60 s old observations: far beyond the latency threshold.
+    observations = [_obs(60.0), _obs(65.0)]
+    result = compute_sdsp_heartbeat(observations, now=now)
+    assert result["meets_sla_surveillance_requirements"] is False
+    assert result["average_latency_or_95_percentile_latency_ms"] >= 1000
+
+
+def test_compute_sdsp_heartbeat_poor_accuracy_breaks_sla():
+    """Fresh but inaccurate observations => surveillance SLA False."""
+    now = datetime.now(tz=timezone.utc)
+    observations = [_obs(0.1, hacc=50.0, vacc=50.0)]
+    result = compute_sdsp_heartbeat(observations, now=now)
+    assert result["meets_sla_surveillance_requirements"] is False
+    assert result["horizontal_or_vertical_95_percentile_accuracy_m"] >= 10.0
+
+
+# ── GET get_air_traffic ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_get_air_traffic_empty(client):
+    """Patched Redis read returns [] => empty observations list, 200."""
+    with patch("flight_blender.routers.surveillance.read_all_observations", return_value=[]):
+        response = await client.get(f"{BASE}/get_air_traffic")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["observations"] == []
+
+
+@pytest.mark.anyio
+async def test_get_air_traffic_with_observations(client):
+    """Seeded observations are mapped into the response payload."""
+    sample = [
+        {"icao_address": "ABC123", "lat_dd": "51.5", "lon_dd": "-0.1", "timestamp": "2026-05-31T00:00:00+00:00"},
+        {"icao_address": "DEF456", "lat_dd": "52.0", "lon_dd": "-1.0", "timestamp": "2026-05-31T00:00:01+00:00"},
+    ]
+    with patch("flight_blender.routers.surveillance.read_all_observations", return_value=sample):
+        response = await client.get(f"{BASE}/get_air_traffic")
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["observations"]) == 2
+    assert body["observations"][0]["icao_address"] == "ABC123"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -221,16 +221,15 @@ class TestGeoFenceTasks:
 class TestSurveillanceTasks:
     def test_get_sync_engine_builds_url(self):
         """_get_sync_engine should convert async URL to sync."""
-        import os
+        with patch("flight_blender.common.sync_engine.create_engine") as mock_create:
+            mock_create.return_value = MagicMock()
+            from flight_blender.common.sync_engine import get_sync_engine
 
-        with patch.dict(os.environ, {"DATABASE_URL": "sqlite+aiosqlite://:memory:"}):
-            with patch("sqlalchemy.create_engine") as mock_create:
-                mock_create.return_value = MagicMock()
-                from flight_blender.tasks.surveillance import _get_sync_engine
-
-                _get_sync_engine()
-                call_url = mock_create.call_args[0][0]
-                assert "+aiosqlite" not in call_url
+            get_sync_engine.cache_clear()
+            get_sync_engine("sqlite+aiosqlite://:memory:")
+            call_url = mock_create.call_args[0][0]
+            assert "+aiosqlite" not in call_url
+            get_sync_engine.cache_clear()
 
     def test_send_heartbeat_session_not_found(self):
         """If the surveillance session doesn't exist, task should return without error."""

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -7,6 +7,7 @@ a real Celery broker, database, or Redis instance.
 
 import json
 import os
+import uuid
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
@@ -273,73 +274,91 @@ class TestSurveillanceTasks:
 # conformance task helpers
 # ---------------------------------------------------------------------------
 class TestConformanceTasks:
+    # NOTE: these tests were updated when the conformance tasks moved from the
+    # `state == 2 => conforming` stub to the real C2-C11 engine. The tasks now
+    # import `create_engine` / `Session` / `read_latest_observation` at module
+    # level, so they are patched at `flight_blender.tasks.conformance.*`. The
+    # "conforming" expectation now also requires fresh telemetry within the
+    # liveness window, and the telemetry task writes its own ConformanceRecord
+    # (it no longer just dispatches `check_flight_conformance`).
+    _VALID_ID = "00000000-0000-0000-0000-000000000001"
+
     def test_check_flight_conformance_declaration_not_found(self):
         """When declaration not found, task should log and return without error."""
-        mock_engine = MagicMock()
         mock_session_obj = MagicMock()
         mock_session_obj.__enter__ = MagicMock(return_value=mock_session_obj)
         mock_session_obj.__exit__ = MagicMock(return_value=False)
         mock_session_obj.get.return_value = None
 
         with (
-            patch("sqlalchemy.create_engine", return_value=mock_engine),
-            patch("sqlalchemy.orm.Session", return_value=mock_session_obj),
+            patch("flight_blender.tasks.conformance.create_engine"),
+            patch("flight_blender.tasks.conformance.Session", return_value=mock_session_obj),
         ):
             from flight_blender.tasks.conformance import check_flight_conformance
 
-            # Should return without raising
-            check_flight_conformance("00000000-0000-0000-0000-000000000001")
+            check_flight_conformance(self._VALID_ID)
+            mock_session_obj.add.assert_not_called()
 
     def test_check_flight_conformance_creates_record(self):
-        """When declaration exists, a ConformanceRecord should be created."""
-        mock_engine = MagicMock()
+        """An Activated declaration with fresh telemetry yields a conforming record."""
         mock_session_obj = MagicMock()
         mock_session_obj.__enter__ = MagicMock(return_value=mock_session_obj)
         mock_session_obj.__exit__ = MagicMock(return_value=False)
 
         fake_decl = MagicMock()
-        fake_decl.id = "some-uuid"
-        fake_decl.state = 2  # ACTIVATED → conforming
+        fake_decl.id = uuid.uuid4()
+        fake_decl.state = 2  # Activated
+        fake_decl.latest_telemetry_datetime = datetime.now(timezone.utc)
         mock_session_obj.get.return_value = fake_decl
 
         with (
-            patch("sqlalchemy.create_engine", return_value=mock_engine),
-            patch("sqlalchemy.orm.Session", return_value=mock_session_obj),
+            patch("flight_blender.tasks.conformance.create_engine"),
+            patch("flight_blender.tasks.conformance.Session", return_value=mock_session_obj),
         ):
             from flight_blender.tasks.conformance import check_flight_conformance
 
-            check_flight_conformance("00000000-0000-0000-0000-000000000001")
+            check_flight_conformance(self._VALID_ID)
             mock_session_obj.add.assert_called_once()
             mock_session_obj.commit.assert_called_once()
+            record = mock_session_obj.add.call_args[0][0]
+            assert record.conformance_state == 1
 
     def test_check_operation_telemetry_conformance_no_telemetry(self):
         """When no telemetry exists, task should return without error."""
-        with patch("flight_blender.common.redis_stream_operations.read_latest_observation", return_value=None):
+        with patch("flight_blender.tasks.conformance.read_latest_observation", return_value=None):
             from flight_blender.tasks.conformance import check_operation_telemetry_conformance
 
-            # Should return without raising
-            check_operation_telemetry_conformance("00000000-0000-0000-0000-000000000001")
+            check_operation_telemetry_conformance(self._VALID_ID)
 
     def test_check_operation_telemetry_conformance_with_telemetry(self):
-        """When telemetry exists, dispatches conformance check."""
-        mock_engine = MagicMock()
+        """When telemetry exists, the task writes a telemetry ConformanceRecord."""
         mock_session_obj = MagicMock()
         mock_session_obj.__enter__ = MagicMock(return_value=mock_session_obj)
         mock_session_obj.__exit__ = MagicMock(return_value=False)
         fake_decl = MagicMock()
+        fake_decl.id = uuid.uuid4()
+        fake_decl.state = 2
+        fake_decl.aircraft_id = "ABC"
+        fake_decl.start_datetime = datetime.now(timezone.utc) - timedelta(hours=1)
+        fake_decl.end_datetime = datetime.now(timezone.utc) + timedelta(hours=1)
+        fake_decl.operational_intent = "{}"
         mock_session_obj.get.return_value = fake_decl
+        mock_session_obj.execute.return_value.scalars.return_value.all.return_value = []
 
         with (
-            patch("flight_blender.common.redis_stream_operations.read_latest_observation", return_value={"lat_dd": "10.0"}),
-            patch("sqlalchemy.create_engine", return_value=mock_engine),
-            patch("sqlalchemy.orm.Session", return_value=mock_session_obj),
-            patch("flight_blender.tasks.conformance.check_flight_conformance") as mock_check,
+            patch(
+                "flight_blender.tasks.conformance.read_latest_observation",
+                return_value={"lat_dd": "10.0", "lon_dd": "20.0", "altitude_mm": 0, "icao_address": "ABC"},
+            ),
+            patch("flight_blender.tasks.conformance.create_engine"),
+            patch("flight_blender.tasks.conformance.Session", return_value=mock_session_obj),
         ):
-            mock_check.delay = MagicMock()
             from flight_blender.tasks.conformance import check_operation_telemetry_conformance
 
-            check_operation_telemetry_conformance("00000000-0000-0000-0000-000000000001")
-            mock_check.delay.assert_called_once()
+            check_operation_telemetry_conformance(self._VALID_ID)
+            mock_session_obj.add.assert_called_once()
+            record = mock_session_obj.add.call_args[0][0]
+            assert record.event_type == "telemetry_check"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -523,6 +523,77 @@ class TestFlightDeclarationTasks:
             assert fake_decl.state == 1
             mock_db.commit.assert_called_once()
 
+    def test_submit_declaration_sends_real_extents_from_volumes(self):
+        """The DSS op-intent PUT carries the operation's stored volumes as ``extents``
+        (was hard-coded ``[]``), built via the utm_adapter reference-payload builder."""
+        from flight_blender.tasks.flight_declaration import submit_flight_declaration_to_dss_async
+
+        volumes = [
+            {
+                "volume": {
+                    "outline_polygon": {"vertices": [{"lat": 1.0, "lng": 2.0}, {"lat": 1.0, "lng": 3.0}, {"lat": 2.0, "lng": 3.0}]},
+                    "altitude_lower": {"value": 0.0},
+                    "altitude_upper": {"value": 120.0},
+                },
+                "time_start": {"value": "2030-01-01T00:00:00Z"},
+                "time_end": {"value": "2030-01-01T01:00:00Z"},
+            }
+        ]
+        fake_decl = MagicMock()
+        fake_decl.state = 0
+        fake_decl.id = "decl-id"
+        fake_decl.end_datetime = datetime.now(tz=timezone.utc) + timedelta(hours=2)
+        fake_decl.operational_intent = json.dumps(volumes)
+        mock_db = self._make_session_mock(declaration=fake_decl)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        mock_resp.json.return_value = {"operational_intent_reference": {}}
+        mock_creds_instance = MagicMock()
+        mock_creds_instance.get_cached_credentials.return_value = {"access_token": "token123"}
+
+        with (
+            patch("sqlalchemy.create_engine"),
+            patch("sqlalchemy.orm.Session", return_value=mock_db),
+            patch("flight_blender.auth.dss_auth_helper.AuthorityCredentialsGetter", return_value=mock_creds_instance),
+            patch("requests.put", return_value=mock_resp) as mock_put,
+        ):
+            submit_flight_declaration_to_dss_async("00000000-0000-0000-0000-000000000001")
+
+        mock_put.assert_called_once()
+        body = mock_put.call_args.kwargs["json"]
+        assert body["extents"] == volumes
+        # No live DSS area query yet, so the airspace key stays empty (documented follow-up).
+        assert body["key"] == []
+
+    def test_submit_declaration_empty_op_intent_sends_empty_extents(self):
+        """A declaration whose operational_intent is ``{}`` yields ``extents=[]`` (no crash)."""
+        from flight_blender.tasks.flight_declaration import submit_flight_declaration_to_dss_async
+
+        fake_decl = MagicMock()
+        fake_decl.state = 0
+        fake_decl.id = "decl-id"
+        fake_decl.end_datetime = datetime.now(tz=timezone.utc) + timedelta(hours=2)
+        fake_decl.operational_intent = "{}"
+        mock_db = self._make_session_mock(declaration=fake_decl)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        mock_resp.json.return_value = {"operational_intent_reference": {}}
+        mock_creds_instance = MagicMock()
+        mock_creds_instance.get_cached_credentials.return_value = {"access_token": "token123"}
+
+        with (
+            patch("sqlalchemy.create_engine"),
+            patch("sqlalchemy.orm.Session", return_value=mock_db),
+            patch("flight_blender.auth.dss_auth_helper.AuthorityCredentialsGetter", return_value=mock_creds_instance),
+            patch("requests.put", return_value=mock_resp) as mock_put,
+        ):
+            submit_flight_declaration_to_dss_async("00000000-0000-0000-0000-000000000001")
+
+        body = mock_put.call_args.kwargs["json"]
+        assert body["extents"] == []
+
     def test_submit_declaration_dss_failure(self):
         """When DSS returns non-201, declaration state should be Rejected."""
         from flight_blender.tasks.flight_declaration import submit_flight_declaration_to_dss_async

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -514,7 +514,7 @@ class TestFlightDeclarationTasks:
         with (
             patch("sqlalchemy.create_engine"),
             patch("sqlalchemy.orm.Session", return_value=mock_db),
-            patch("flight_blender.auth.dss_auth_helper.AuthorityCredentialsGetter", return_value=mock_creds_instance),
+            patch("flight_blender.auth.dss.AuthorityCredentialsGetter", return_value=mock_creds_instance),
             patch("requests.put", return_value=mock_resp),
         ):
             submit_flight_declaration_to_dss_async("00000000-0000-0000-0000-000000000001")
@@ -554,7 +554,7 @@ class TestFlightDeclarationTasks:
         with (
             patch("sqlalchemy.create_engine"),
             patch("sqlalchemy.orm.Session", return_value=mock_db),
-            patch("flight_blender.auth.dss_auth_helper.AuthorityCredentialsGetter", return_value=mock_creds_instance),
+            patch("flight_blender.auth.dss.AuthorityCredentialsGetter", return_value=mock_creds_instance),
             patch("requests.put", return_value=mock_resp) as mock_put,
         ):
             submit_flight_declaration_to_dss_async("00000000-0000-0000-0000-000000000001")
@@ -585,7 +585,7 @@ class TestFlightDeclarationTasks:
         with (
             patch("sqlalchemy.create_engine"),
             patch("sqlalchemy.orm.Session", return_value=mock_db),
-            patch("flight_blender.auth.dss_auth_helper.AuthorityCredentialsGetter", return_value=mock_creds_instance),
+            patch("flight_blender.auth.dss.AuthorityCredentialsGetter", return_value=mock_creds_instance),
             patch("requests.put", return_value=mock_resp) as mock_put,
         ):
             submit_flight_declaration_to_dss_async("00000000-0000-0000-0000-000000000001")
@@ -613,7 +613,7 @@ class TestFlightDeclarationTasks:
         with (
             patch("sqlalchemy.create_engine"),
             patch("sqlalchemy.orm.Session", return_value=mock_db),
-            patch("flight_blender.auth.dss_auth_helper.AuthorityCredentialsGetter", return_value=mock_creds_instance),
+            patch("flight_blender.auth.dss.AuthorityCredentialsGetter", return_value=mock_creds_instance),
             patch("requests.put", return_value=mock_resp),
         ):
             submit_flight_declaration_to_dss_async("00000000-0000-0000-0000-000000000001")
@@ -675,7 +675,7 @@ class TestRidTasks:
         with (
             patch("sqlalchemy.create_engine"),
             patch("sqlalchemy.orm.Session", return_value=mock_db),
-            patch("flight_blender.auth.dss_auth_helper.AuthorityCredentialsGetter", return_value=mock_creds_instance),
+            patch("flight_blender.auth.dss.AuthorityCredentialsGetter", return_value=mock_creds_instance),
             patch("requests.put", return_value=mock_resp),
         ):
             submit_dss_subscription("00000000-0000-0000-0000-000000000001", "10,20,30,40", "2030-01-01T00:00:00Z")
@@ -700,7 +700,7 @@ class TestRidTasks:
         with (
             patch("sqlalchemy.create_engine"),
             patch("sqlalchemy.orm.Session", return_value=mock_db),
-            patch("flight_blender.auth.dss_auth_helper.AuthorityCredentialsGetter", return_value=mock_creds_instance),
+            patch("flight_blender.auth.dss.AuthorityCredentialsGetter", return_value=mock_creds_instance),
             patch("requests.put", return_value=mock_resp),
         ):
             submit_dss_subscription("00000000-0000-0000-0000-000000000001", "10,20,30,40", "2030-01-01T00:00:00Z")

--- a/tests/test_telemetry_verifier.py
+++ b/tests/test_telemetry_verifier.py
@@ -1,0 +1,116 @@
+"""Unit tests for signed-RID-telemetry verification.
+
+The peer-RID / signed-telemetry path verifies an IETF HTTP Message Signature
+(RFC 9421, RSA-PSS-SHA512) against the public keys registered as
+``SignedTelemetryPublicKey`` rows — ported from Django
+``flight_feed_operations/pki_helper.py`` (``MessageVerifier``).
+
+These tests exercise the pure verifier (no network, no DB) by signing a request
+with an in-test RSA keypair and checking:
+
+* a valid signature over an intact body is accepted,
+* a tampered body is rejected (the ``Content-Digest`` must bind the body),
+* an absent/garbage signature is rejected,
+* an unknown key (signature made with a different key) is rejected,
+* no configured keys → rejected.
+"""
+
+import hashlib
+import json
+
+import http_sfv
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from http_message_signatures import HTTPMessageSigner, HTTPSignatureKeyResolver, algorithms
+from jwt.algorithms import RSAAlgorithm
+
+from flight_blender.services.telemetry_verifier import verify_signed_request
+
+METHOD = "POST"
+URL = "http://test/flight_stream/set_signed_telemetry"
+
+
+def _keypair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key, private_key.public_key()
+
+
+def _jwk(public_key, kid: str) -> dict:
+    data = json.loads(RSAAlgorithm.to_jwk(public_key))
+    data["kid"] = kid
+    return data
+
+
+def _content_digest(body: bytes) -> str:
+    return str(http_sfv.Dictionary({"sha-256": hashlib.sha256(body).digest()}))
+
+
+class _Req:
+    def __init__(self, method, url, headers, body):
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.body = body
+
+
+def _sign(private_key, kid: str, body: bytes) -> dict:
+    """Sign a request the way Django's ResponseSigningOperations.sign_http_message does."""
+
+    class _KR(HTTPSignatureKeyResolver):
+        def resolve_private_key(self, key_id):
+            return private_key
+
+        def resolve_public_key(self, key_id=None):
+            return private_key.public_key()
+
+    req = _Req(METHOD, URL, {"Content-Digest": _content_digest(body), "Content-Type": "application/json"}, body)
+    signer = HTTPMessageSigner(signature_algorithm=algorithms.RSA_PSS_SHA512, key_resolver=_KR())
+    signer.sign(
+        req,
+        key_id=kid,
+        covered_component_ids=("@method", "@authority", "@target-uri", "content-digest"),
+        label="sig1",
+    )
+    return dict(req.headers)
+
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_valid_signature_accepted():
+    private_key, public_key = _keypair()
+    body = json.dumps({"observations": [{"id": "A"}]}).encode()
+    headers = _sign(private_key, "key-1", body)
+    assert await verify_signed_request(METHOD, URL, headers, body, [_jwk(public_key, "key-1")]) is True
+
+
+async def test_tampered_body_rejected():
+    private_key, public_key = _keypair()
+    body = json.dumps({"observations": [{"id": "A"}]}).encode()
+    headers = _sign(private_key, "key-1", body)
+    tampered = json.dumps({"observations": [{"id": "EVIL"}]}).encode()
+    assert await verify_signed_request(METHOD, URL, headers, tampered, [_jwk(public_key, "key-1")]) is False
+
+
+async def test_missing_signature_rejected():
+    _private_key, public_key = _keypair()
+    body = b"{}"
+    # No Signature/Signature-Input headers at all.
+    headers = {"Content-Digest": _content_digest(body), "Content-Type": "application/json"}
+    assert await verify_signed_request(METHOD, URL, headers, body, [_jwk(public_key, "key-1")]) is False
+
+
+async def test_unknown_key_rejected():
+    signing_key, _ = _keypair()
+    _, other_public = _keypair()
+    body = json.dumps({"observations": []}).encode()
+    headers = _sign(signing_key, "key-1", body)
+    # Verify against a *different* public key.
+    assert await verify_signed_request(METHOD, URL, headers, body, [_jwk(other_public, "key-1")]) is False
+
+
+async def test_no_keys_rejected():
+    private_key, _ = _keypair()
+    body = b"{}"
+    headers = _sign(private_key, "key-1", body)
+    assert await verify_signed_request(METHOD, URL, headers, body, []) is False

--- a/tests/test_uss_interop.py
+++ b/tests/test_uss_interop.py
@@ -71,6 +71,7 @@ def use_jwks(monkeypatch):
                 return types.SimpleNamespace(key=public_key)
 
         monkeypatch.setattr(jb.jwt, "PyJWKClient", _FakeJWKClient)
+        jb._get_jwks_client.cache_clear()
 
     return _install
 

--- a/tests/test_uss_interop.py
+++ b/tests/test_uss_interop.py
@@ -1,0 +1,169 @@
+"""Peer-USS RID interop parity tests.
+
+Django served the USS-to-USS Remote-ID exchange endpoints under ``/uss/...``
+guarded by the RID-specific scope ``rid.display_provider`` (see Django
+``uss_operations/urls.py`` + ``uss_operations/views.py``):
+
+* ``GET /uss/flights``                       → ``rid.display_provider``
+* ``GET /uss/flights/<flight_id>/details``   → ``rid.display_provider``
+
+The FastAPI migration moved these to ``/uss_ops/...`` and guarded them with the
+generic blender read scope, breaking interop with other USSs. These tests pin:
+
+1. the Django-compatible path responds (``/uss/flights*``), while the
+   ``/uss_ops`` alias is also kept for back-compat, and
+2. the endpoints enforce the *real* ``rid.display_provider`` scope — proven with
+   the non-bypassed JWT path (bypass switched OFF + a fake JWKS), mirroring
+   ``tests/test_auth_verification.py``.
+"""
+
+import time
+import types
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+import flight_blender.auth.jwt_bearer as jb
+
+# ── Scope-enforcement helpers (mirror test_auth_verification.py) ────────────────
+
+
+def _keypair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key, private_key.public_key()
+
+
+def _sign(private_key, **claims) -> str:
+    return jwt.encode(claims, private_key, algorithm="RS256")
+
+
+def _creds(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def _settings(**overrides):
+    base = dict(
+        bypass_auth_token_verification=False,
+        auth_server_jwks_uri="https://jwks.test",
+        auth_audience="",
+        flightblender_read_scope="blender.read",
+        flightblender_write_scope="blender.write",
+        rid_display_provider_scope="rid.display_provider",
+        rid_service_provider_scope="rid.service_provider",
+    )
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+@pytest.fixture
+def use_jwks(monkeypatch):
+    """Install a fake PyJWKClient whose signing key is the given public key."""
+
+    def _install(public_key):
+        class _FakeJWKClient:
+            def __init__(self, *_a, **_kw):
+                pass
+
+            def get_signing_key_from_jwt(self, _token):
+                return types.SimpleNamespace(key=public_key)
+
+        monkeypatch.setattr(jb.jwt, "PyJWKClient", _FakeJWKClient)
+
+    return _install
+
+
+def _valid_claims(scope: str, **overrides):
+    claims = {
+        "exp": int(time.time()) + 3600,
+        "iss": "https://issuer.example.test",
+        "scope": scope,
+    }
+    claims.update(overrides)
+    return claims
+
+
+# ── 1. Django-compatible path responds (and /uss_ops alias kept) ────────────────
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("base", ["/uss", "/uss_ops"])
+async def test_get_uss_flights_path(client, base):
+    """``GET <base>/flights`` responds (200) at the Django path and the alias."""
+    resp = await client.get(f"{base}/flights?view=-1.0,51.0,1.0,52.0")
+    assert resp.status_code == 200
+    assert "flights" in resp.json()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("base", ["/uss", "/uss_ops"])
+async def test_get_uss_flight_details_path(client, base):
+    """``GET <base>/flights/<id>/details`` returns 404 for an unknown flight."""
+    resp = await client.get(f"{base}/flights/UNKNOWN-FLIGHT/details")
+    assert resp.status_code == 404
+
+
+# ── 2. The RID-specific scope is actually enforced (real JWT path) ──────────────
+
+
+def _rid_display_dep():
+    """Resolve the require_scope dependency callable for rid.display_provider."""
+    return jb.require_scope("rid.display_provider")
+
+
+@pytest.mark.anyio
+async def test_uss_flights_requires_rid_display_provider_scope(monkeypatch, use_jwks):
+    """A token without ``rid.display_provider`` is rejected (403); with it, accepted."""
+    private_key, public_key = _keypair()
+    use_jwks(public_key)
+    monkeypatch.setattr(jb, "settings", _settings())
+
+    dependency = _rid_display_dep()
+
+    # Wrong scope (only the generic blender scopes) → 403.
+    bad_token = _sign(private_key, **_valid_claims(scope="blender.read blender.write"))
+    bad_payload = await jb._get_token_payload(_creds(bad_token))
+    with pytest.raises(HTTPException) as exc:
+        await dependency(bad_payload)
+    assert exc.value.status_code == 403
+
+    # Correct RID scope → accepted.
+    good_token = _sign(private_key, **_valid_claims(scope="rid.display_provider"))
+    good_payload = await jb._get_token_payload(_creds(good_token))
+    result = await dependency(good_payload)
+    assert "rid.display_provider" in result["scope"]
+
+
+@pytest.mark.anyio
+async def test_uss_rid_routes_declare_display_provider_scope():
+    """The mounted /uss/flights* routes must require rid.display_provider, not blender.read.
+
+    This guards against the migration regression where these peer-USS RID
+    endpoints were guarded with the generic blender read scope.
+    """
+    from flight_blender.config import get_settings
+    from flight_blender.main import create_app
+
+    settings = get_settings()
+    app = create_app()
+    rid_scope = settings.rid_display_provider_scope
+
+    targets = {"/uss/flights", "/uss/flights/{flight_id}/details"}
+    seen = set()
+    for route in app.routes:
+        if getattr(route, "path", None) in targets and "GET" in (getattr(route, "methods", set()) or set()):
+            seen.add(route.path)
+            # Collect every scope referenced by this route's dependencies.
+            scopes: set[str] = set()
+            for dep in route.dependant.dependencies:
+                closure = getattr(dep.call, "__closure__", None) or ()
+                for cell in closure:
+                    val = cell.cell_contents
+                    if isinstance(val, tuple):
+                        scopes.update(s for s in val if isinstance(s, str))
+            assert rid_scope in scopes, f"{route.path} must require {rid_scope}; saw {scopes}"
+            assert settings.flightblender_read_scope not in scopes, f"{route.path} must not require the generic read scope"
+
+    assert seen == targets, f"missing Django-compatible RID routes: {targets - seen}"

--- a/tests/test_ussp_gate.py
+++ b/tests/test_ussp_gate.py
@@ -1,0 +1,149 @@
+"""
+Tests for honoring the USSP_NETWORK_ENABLED gate on the flight-declaration
+acceptance / DSS-submission path.
+
+* USSP disabled: a clear declaration is Accepted (state 1) directly, no DSS
+  submission.
+* USSP enabled: a clear declaration is left Processing (state 0) and submitted
+  to the DSS asynchronously.
+
+Mirrors Django views.py: ``if is_approved and declaration_state == 0 and
+ussp_network_enabled and auto_submit_to_dss: submit_..._async.delay(...)``.
+"""
+
+import unittest.mock as mock
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from flight_blender.routers import flight_declaration as fd_router
+from flight_blender.services.deconfliction import resolve_decision
+
+pytestmark = pytest.mark.anyio
+
+BASE = "/flight_declaration_ops"
+
+
+def _payload():
+    start = datetime.now(timezone.utc) + timedelta(hours=1)
+    end = start + timedelta(hours=2)
+    return {
+        "aircraft_id": "TEST-AIRCRAFT",
+        "originating_party": "Test Operator",
+        "start_datetime": start.isoformat(),
+        "end_datetime": end.isoformat(),
+        "flight_declaration_geo_json": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {"min_altitude": {"meters": 50}, "max_altitude": {"meters": 120}},
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[-122.4, 37.7], [-122.4, 37.8], [-122.3, 37.8], [-122.3, 37.7], [-122.4, 37.7]]],
+                    },
+                }
+            ],
+        },
+        "type_of_operation": 0,
+    }
+
+
+class TestUSSPDecisionLogic:
+    def test_clear_without_network_is_accepted(self):
+        d = resolve_decision(engine_error=False, is_clear=True, ussp_network_enabled=False)
+        assert (d.is_approved, d.declaration_state) == (True, 1)
+
+    def test_clear_with_network_is_pending(self):
+        d = resolve_decision(engine_error=False, is_clear=True, ussp_network_enabled=True)
+        assert (d.is_approved, d.declaration_state) == (True, 0)
+
+    def test_conflict_is_rejected_regardless_of_network(self):
+        for net in (False, True):
+            d = resolve_decision(engine_error=False, is_clear=False, ussp_network_enabled=net)
+            assert (d.is_approved, d.declaration_state) == (False, 8)
+
+
+def _enable_ussp():
+    """Patch settings so the USSP network gate is on (and auto-submit enabled)."""
+    settings = fd_router.get_settings()
+    return (
+        mock.patch.object(settings, "ussp_network_enabled", 1),
+        mock.patch.object(settings, "auto_submit_to_dss", 1),
+    )
+
+
+class TestUSSPSubmissionGate:
+    async def test_no_dss_submission_when_network_disabled(self, client):
+        # Clear deconfliction, state Accepted (1) -> no DSS submission.
+        with (
+            mock.patch.object(fd_router, "_run_deconfliction", return_value=(True, 1)),
+            mock.patch.object(fd_router.submit_flight_declaration_to_dss_async, "delay") as delay_mock,
+        ):
+            resp = await client.post(f"{BASE}/set_flight_declaration", json=_payload())
+        assert resp.status_code in (200, 201)
+        assert resp.json()["state"] == 1
+        delay_mock.assert_not_called()
+
+    async def test_dss_submission_when_network_enabled(self, client):
+        # Clear deconfliction with USSP -> state Processing (0) and DSS submission.
+        p_ussp, p_auto = _enable_ussp()
+        with (
+            p_ussp,
+            p_auto,
+            mock.patch.object(fd_router, "_run_deconfliction", return_value=(True, 0)),
+            mock.patch.object(fd_router.submit_flight_declaration_to_dss_async, "delay") as delay_mock,
+        ):
+            resp = await client.post(f"{BASE}/set_flight_declaration", json=_payload())
+        assert resp.status_code in (200, 201)
+        assert resp.json()["state"] == 0
+        delay_mock.assert_called_once()
+
+    async def test_no_dss_submission_on_conflict(self, client):
+        p_ussp, p_auto = _enable_ussp()
+        with (
+            p_ussp,
+            p_auto,
+            mock.patch.object(fd_router, "_run_deconfliction", return_value=(False, 8)),
+            mock.patch.object(fd_router.submit_flight_declaration_to_dss_async, "delay") as delay_mock,
+        ):
+            resp = await client.post(f"{BASE}/set_flight_declaration", json=_payload())
+        assert resp.status_code in (200, 201)
+        assert resp.json()["state"] == 8
+        delay_mock.assert_not_called()
+
+    async def test_op_intent_submission_when_network_enabled(self, client):
+        start = datetime.now(timezone.utc) + timedelta(hours=1)
+        end = start + timedelta(hours=2)
+        op_payload = {
+            "operational_intent_volume4ds": [
+                {
+                    "volume": {
+                        "outline_polygon": {
+                            "vertices": [
+                                {"lng": -122.4, "lat": 37.7},
+                                {"lng": -122.4, "lat": 37.8},
+                                {"lng": -122.3, "lat": 37.8},
+                                {"lng": -122.3, "lat": 37.7},
+                            ]
+                        },
+                        "altitude_lower": {"value": 50},
+                        "altitude_upper": {"value": 120},
+                    }
+                }
+            ],
+            "start_datetime": start.isoformat(),
+            "end_datetime": end.isoformat(),
+            "aircraft_id": "test-aircraft",
+        }
+        p_ussp, p_auto = _enable_ussp()
+        with (
+            p_ussp,
+            p_auto,
+            mock.patch.object(fd_router, "_run_deconfliction", return_value=(True, 0)),
+            mock.patch.object(fd_router.submit_flight_declaration_to_dss_async, "delay") as delay_mock,
+        ):
+            resp = await client.post(f"{BASE}/set_operational_intent", json=op_payload)
+        assert resp.status_code in (200, 201)
+        assert resp.json()["state"] == 0
+        delay_mock.assert_called_once()

--- a/tests/test_utm_daa.py
+++ b/tests/test_utm_daa.py
@@ -56,13 +56,14 @@ async def test_get_daa_incident_logs_with_date_filters(client):
 
 
 @pytest.mark.anyio
-async def test_get_daa_incident_logs_invalid_date_gracefully_ignored(client):
-    # Invalid date filters should be ignored, not cause a 500 error
+async def test_get_daa_incident_logs_invalid_date_rejected(client):
+    # A malformed date filter must be rejected with 422, not silently ignored
+    # (the original port swallowed the ValueError and returned unfiltered results).
     response = await client.get(
         f"{BASE}/logs/incident/",
         params={"start_date": "not-a-date"},
     )
-    assert response.status_code == 200
+    assert response.status_code == 422
 
 
 @pytest.mark.anyio

--- a/tests/test_utm_daa.py
+++ b/tests/test_utm_daa.py
@@ -81,13 +81,13 @@ async def test_get_daa_incident_logs_all_filters(client):
 
 
 @pytest.mark.anyio
-async def test_list_alerts_malformed_start_date_returns_422(client):
-    """A malformed start_date must be rejected (was silently swallowed)."""
-    response = await client.get("/detect_and_avoid_ops/alerts", params={"start_date": "not-a-date"})
+async def test_incident_logs_malformed_start_date_returns_422(client):
+    """A malformed start_date must be rejected, not silently ignored."""
+    response = await client.get(f"{BASE}/logs/incident/", params={"start_date": "not-a-date"})
     assert response.status_code == 422
 
 
 @pytest.mark.anyio
-async def test_list_alerts_malformed_end_date_returns_422(client):
-    response = await client.get("/detect_and_avoid_ops/alerts", params={"end_date": "13/13/2025"})
+async def test_incident_logs_malformed_end_date_returns_422(client):
+    response = await client.get(f"{BASE}/logs/incident/", params={"end_date": "13/13/2025"})
     assert response.status_code == 422

--- a/tests/test_utm_daa.py
+++ b/tests/test_utm_daa.py
@@ -78,3 +78,16 @@ async def test_get_daa_incident_logs_all_filters(client):
     )
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+
+@pytest.mark.anyio
+async def test_list_alerts_malformed_start_date_returns_422(client):
+    """A malformed start_date must be rejected (was silently swallowed)."""
+    response = await client.get("/detect_and_avoid_ops/alerts", params={"start_date": "not-a-date"})
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_list_alerts_malformed_end_date_returns_422(client):
+    response = await client.get("/detect_and_avoid_ops/alerts", params={"end_date": "13/13/2025"})
+    assert response.status_code == 422

--- a/tests/test_utm_flight_declaration_advanced.py
+++ b/tests/test_utm_flight_declaration_advanced.py
@@ -293,3 +293,48 @@ async def test_submit_to_dss(client):
 async def test_submit_to_dss_not_found(client):
     response = await client.post(f"{BASE}/flight_declaration/{uuid.uuid4()}/submit_to_dss")
     assert response.status_code == 404
+
+
+# ── Bulk endpoints run strategic deconfliction (regression guard) ──────────────
+
+
+@pytest.mark.anyio
+async def test_bulk_create_flight_declarations_runs_deconfliction(client, monkeypatch):
+    """Bulk flight-declaration create must run deconfliction, not optimistically approve."""
+    from flight_blender.common.enums import OperationState
+    from flight_blender.routers import flight_declaration as fd_router
+
+    async def fake_run_deconfliction(*args, **kwargs):
+        return False, int(OperationState.REJECTED)
+
+    monkeypatch.setattr(fd_router, "_run_deconfliction", fake_run_deconfliction)
+
+    response = await client.post(f"{BASE}/set_flight_declarations_bulk", json=[FULL_REQUEST_PAYLOAD])
+    assert response.status_code == 200
+    created_id = response.json()["results"][0]["id"]
+
+    detail = await client.get(f"{BASE}/flight_declaration/{created_id}")
+    assert detail.status_code == 200
+    assert detail.json()["is_approved"] is False
+    assert detail.json()["state"] == int(OperationState.REJECTED)
+
+
+@pytest.mark.anyio
+async def test_bulk_set_operational_intents_runs_deconfliction(client, monkeypatch):
+    """Bulk op-intent create must run deconfliction, not optimistically approve."""
+    from flight_blender.common.enums import OperationState
+    from flight_blender.routers import flight_declaration as fd_router
+
+    async def fake_run_deconfliction(*args, **kwargs):
+        return False, int(OperationState.REJECTED)
+
+    monkeypatch.setattr(fd_router, "_run_deconfliction", fake_run_deconfliction)
+
+    response = await client.post(f"{BASE}/set_operational_intents_bulk", json=[OP_INTENT_PAYLOAD])
+    assert response.status_code == 200
+    created_id = response.json()["results"][0]["id"]
+
+    detail = await client.get(f"{BASE}/flight_declaration/{created_id}")
+    assert detail.status_code == 200
+    assert detail.json()["is_approved"] is False
+    assert detail.json()["state"] == int(OperationState.REJECTED)

--- a/tests/test_utm_misc.py
+++ b/tests/test_utm_misc.py
@@ -85,26 +85,33 @@ async def test_get_weather_returns_200(client):
     response = await client.get("/weather_monitoring_ops/weather/", params={"latitude": 51.5, "longitude": -0.1})
     assert response.status_code == 200
     body = response.json()
+    # Django parity: latitude/longitude come from the upstream response, the full
+    # WeatherSerializer shape is returned, and there is no synthetic current_weather.
     assert body["latitude"] == 51.5
     assert body["longitude"] == -0.1
+    assert "hourly" in body
+    assert "current_weather" not in body
 
 
 @pytest.mark.anyio
-async def test_get_weather_invalid_latitude(client):
+async def test_get_weather_out_of_range_latitude_is_forwarded(client):
+    # Django did presence-only validation (no range bounds); out-of-range
+    # coordinates are forwarded upstream rather than rejected with 422.
     response = await client.get("/weather_monitoring_ops/weather/", params={"latitude": 999.0, "longitude": -0.1})
-    assert response.status_code == 422
+    assert response.status_code == 200
 
 
 @pytest.mark.anyio
-async def test_get_weather_invalid_longitude(client):
+async def test_get_weather_out_of_range_longitude_is_forwarded(client):
     response = await client.get("/weather_monitoring_ops/weather/", params={"latitude": 51.5, "longitude": 999.0})
-    assert response.status_code == 422
+    assert response.status_code == 200
 
 
 @pytest.mark.anyio
 async def test_get_weather_missing_params(client):
     response = await client.get("/weather_monitoring_ops/weather/")
-    assert response.status_code == 422
+    assert response.status_code == 400
+    assert response.json() == {"error": "Longitude parameter is required"}
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -196,10 +203,10 @@ async def test_get_all_flights_uss(client):
 
 @pytest.mark.anyio
 async def test_get_flight_details_uss(client):
+    """Unknown RID flight details return 404 (Django ``get_uss_flight_details``)."""
     flight_id = str(uuid.uuid4())
     response = await client.get(f"/uss_ops/flights/{flight_id}/details")
-    assert response.status_code == 200
-    assert response.json()["id"] == flight_id
+    assert response.status_code == 404
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_utm_surveillance.py
+++ b/tests/test_utm_surveillance.py
@@ -116,8 +116,8 @@ async def test_service_metrics_with_date_filters(client):
     )
     assert response.status_code == 200
     body = response.json()
-    assert body["window_start"] == "2024-01-01T00:00:00"
-    assert body["window_end"] == "2024-12-31T23:59:59"
+    assert body["window_start"] == "2024-01-01T00:00:00+00:00"
+    assert body["window_end"] == "2024-12-31T23:59:59+00:00"
 
 
 @pytest.mark.anyio

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,302 @@
+"""Weather subsystem parity tests (Django -> FastAPI migration).
+
+Covers the weather service param construction (real param-building with a
+mocked HTTP layer) and the weather router (scope enforcement, missing-param
+contract, success/response shape, upstream-failure handling).
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from flight_blender.config import get_settings
+from flight_blender.services.weather_service import WEATHER_TOPICS, WeatherService
+
+pytestmark = pytest.mark.anyio
+
+WEATHER_URL = "/weather_monitoring_ops/weather/"
+
+_UPSTREAM_PAYLOAD = {
+    "latitude": 51.5,
+    "longitude": -0.1,
+    "generationtime_ms": 0.123,
+    "utc_offset_seconds": 0,
+    "timezone": "UTC",
+    "timezone_abbreviation": "GMT",
+    "elevation": 25.0,
+    "hourly_units": {"time": "iso8601", "temperature_2m": "°C"},
+    "hourly": {"time": ["2026-05-30T00:00"], "temperature_2m": [12.3]},
+}
+
+
+# --------------------------------------------------------------------------- #
+# Service: real param-building with a mocked httpx layer
+# --------------------------------------------------------------------------- #
+class _FakeAsyncClient:
+    """Records the URL/params/timeout used and returns a canned response."""
+
+    last_instance: "_FakeAsyncClient | None" = None
+
+    def __init__(self, *args, **kwargs):
+        self.init_kwargs = kwargs
+        self.captured_url = None
+        self.captured_params = None
+        self.captured_timeout = None
+        self.response = httpx.Response(200, json=_UPSTREAM_PAYLOAD)
+        type(self).last_instance = self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def get(self, url, params=None, timeout=None):
+        self.captured_url = url
+        self.captured_params = params
+        self.captured_timeout = timeout
+        return self.response
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    monkeypatch.setattr(
+        "flight_blender.services.weather_service.httpx.AsyncClient",
+        _FakeAsyncClient,
+    )
+    return _FakeAsyncClient
+
+
+async def test_service_forwards_time_and_topics(fake_http):
+    svc = WeatherService(base_url="https://api.example.com/weather")
+    data = await svc.get_weather(longitude=-0.1, latitude=51.5, time=1700000000, timezone="UTC")
+
+    params = fake_http.last_instance.captured_params
+    assert params["longitude"] == -0.1
+    assert params["latitude"] == 51.5
+    assert params["time"] == 1700000000
+    assert params["timezone"] == "UTC"
+    assert params["forecast_days"] == "1"
+    assert params["hourly"] == ",".join(WEATHER_TOPICS)
+    # The full upstream object is returned unchanged (Django parity).
+    assert data == _UPSTREAM_PAYLOAD
+
+
+async def test_service_defaults_time_to_now(fake_http):
+    svc = WeatherService(base_url="https://api.example.com/weather")
+    await svc.get_weather(longitude=-0.1, latitude=51.5, timezone="UTC")
+    params = fake_http.last_instance.captured_params
+    assert "time" in params and params["time"] is not None
+
+
+async def test_service_uses_timeout(fake_http):
+    svc = WeatherService(base_url="https://api.example.com/weather")
+    await svc.get_weather(longitude=-0.1, latitude=51.5, time=1700000000, timezone="UTC")
+    assert fake_http.last_instance.captured_timeout == 30
+
+
+async def test_service_topics_match_django(fake_http):
+    assert WEATHER_TOPICS == [
+        "temperature_2m",
+        "showers",
+        "windspeed_10m",
+        "winddirection_10m",
+        "windgusts_10m",
+    ]
+
+
+async def test_service_raises_on_non_200(monkeypatch):
+    class _ErrClient(_FakeAsyncClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.response = httpx.Response(500, text="upstream boom")
+
+    monkeypatch.setattr(
+        "flight_blender.services.weather_service.httpx.AsyncClient",
+        _ErrClient,
+    )
+    svc = WeatherService(base_url="https://api.example.com/weather")
+    with pytest.raises(ValueError, match="Error fetching weather data"):
+        await svc.get_weather(longitude=-0.1, latitude=51.5, time=1, timezone="UTC")
+
+
+# --------------------------------------------------------------------------- #
+# Router: success / response-shape parity (patched service via conftest)
+# --------------------------------------------------------------------------- #
+async def test_router_success_returns_django_shape(client):
+    resp = await client.get(WEATHER_URL, params={"latitude": 51.5, "longitude": -0.1})
+    assert resp.status_code == 200
+    body = resp.json()
+    # Full upstream object is forwarded; declared Django fields present.
+    for key in (
+        "latitude",
+        "longitude",
+        "generationtime_ms",
+        "utc_offset_seconds",
+        "timezone",
+        "timezone_abbreviation",
+        "elevation",
+        "hourly_units",
+        "hourly",
+    ):
+        assert key in body
+    assert body["generationtime_ms"] == 0.123
+    assert body["elevation"] == 25.0
+    # Django parity: no synthetic current_weather field.
+    assert "current_weather" not in body
+
+
+async def test_router_forwards_time(client, monkeypatch):
+    captured = {}
+
+    async def _fake(self, **kwargs):
+        captured.update(kwargs)
+        return _UPSTREAM_PAYLOAD
+
+    monkeypatch.setattr(WeatherService, "get_weather", _fake)
+    resp = await client.get(WEATHER_URL, params={"latitude": 51.5, "longitude": -0.1, "time": 1700000000})
+    assert resp.status_code == 200
+    assert captured["time"] == 1700000000
+
+
+# --------------------------------------------------------------------------- #
+# Router: validation / error-contract parity (Django: 400 + {"error": ...})
+# --------------------------------------------------------------------------- #
+async def test_router_missing_longitude_returns_400(client):
+    resp = await client.get(WEATHER_URL, params={"latitude": 51.5})
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "Longitude parameter is required"}
+
+
+async def test_router_missing_latitude_returns_400(client):
+    resp = await client.get(WEATHER_URL, params={"longitude": -0.1})
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "Latitude parameter is required"}
+
+
+async def test_router_out_of_range_is_forwarded(client, monkeypatch):
+    # Django did presence-only validation; out-of-range values go upstream.
+    captured = {}
+
+    async def _fake(self, **kwargs):
+        captured.update(kwargs)
+        return _UPSTREAM_PAYLOAD
+
+    monkeypatch.setattr(WeatherService, "get_weather", _fake)
+    resp = await client.get(WEATHER_URL, params={"latitude": 51.5, "longitude": 999.0})
+    assert resp.status_code == 200
+    assert captured["longitude"] == 999.0
+
+
+# --------------------------------------------------------------------------- #
+# Router: upstream-failure handling -> 502 without leaking the upstream body
+# --------------------------------------------------------------------------- #
+async def test_router_upstream_failure_502_no_body_leak(client, monkeypatch):
+    secret = "SENSITIVE-UPSTREAM-DETAIL"
+
+    async def _boom(self, **kwargs):
+        raise ValueError(f"Error fetching weather data: {secret}")
+
+    monkeypatch.setattr(WeatherService, "get_weather", _boom)
+    resp = await client.get(WEATHER_URL, params={"latitude": 51.5, "longitude": -0.1})
+    assert resp.status_code == 502
+    assert secret not in resp.text
+
+
+async def test_router_upstream_httpx_error_502(client, monkeypatch):
+    async def _boom(self, **kwargs):
+        request = httpx.Request("GET", "https://api.example.com/weather")
+        raise httpx.ConnectError("connection refused", request=request)
+
+    monkeypatch.setattr(WeatherService, "get_weather", _boom)
+    resp = await client.get(WEATHER_URL, params={"latitude": 51.5, "longitude": -0.1})
+    assert resp.status_code == 502
+
+
+# --------------------------------------------------------------------------- #
+# Router: scope enforcement via the real (non-bypassed) verification path
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def rsa_keypair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key, private_key.public_key()
+
+
+def _make_token(private_key, *, scope, kid="test-key", **overrides):
+    now = int(time.time())
+    payload = {
+        "iss": "https://issuer.example.com",
+        "aud": "testflight",
+        "sub": "test-user",
+        "scope": scope,
+        "iat": now,
+        "exp": now + 3600,
+    }
+    payload.update(overrides)
+    return pyjwt.encode(payload, private_key, algorithm="RS256", headers={"kid": kid})
+
+
+class _FakeSigningKey:
+    def __init__(self, key):
+        self.key = key
+
+
+@pytest.fixture
+def patch_jwks(monkeypatch, rsa_keypair):
+    _, public_key = rsa_keypair
+    pem = public_key.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    def _fake_get_signing_key_from_jwt(self, token):
+        return _FakeSigningKey(pem)
+
+    monkeypatch.setattr(
+        "flight_blender.auth.jwt_bearer.jwt.PyJWKClient.get_signing_key_from_jwt",
+        _fake_get_signing_key_from_jwt,
+    )
+    yield
+
+
+@pytest.fixture
+def auth_env(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings, "bypass_auth_token_verification", False)
+    monkeypatch.setattr(settings, "auth_server_jwks_uri", "https://issuer.example.com/jwks")
+    monkeypatch.setattr(settings, "auth_audience", "testflight")
+    yield
+
+
+async def test_weather_requires_write_scope(client, patch_jwks, auth_env, rsa_keypair):
+    """Read scope must be rejected: the weather endpoint requires write (Django parity)."""
+    private_key, _ = rsa_keypair
+    token = _make_token(private_key, scope="blender.read")
+    resp = await client.get(
+        WEATHER_URL,
+        params={"latitude": 51.5, "longitude": -0.1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_weather_accepts_write_scope(client, patch_jwks, auth_env, rsa_keypair):
+    private_key, _ = rsa_keypair
+    token = _make_token(private_key, scope="blender.write")
+    resp = await client.get(
+        WEATHER_URL,
+        params={"latitude": 51.5, "longitude": -0.1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code not in (401, 403)
+
+
+async def test_weather_missing_token_rejected(client, patch_jwks, auth_env):
+    resp = await client.get(WEATHER_URL, params={"latitude": 51.5, "longitude": -0.1}, headers={})
+    assert resp.status_code == 401

--- a/tests/test_websocket_auth.py
+++ b/tests/test_websocket_auth.py
@@ -11,6 +11,7 @@ connection works without a token, preserving the existing dev/test behaviour.
 
 import time
 import types
+from unittest.mock import AsyncMock, patch
 
 import jwt
 import pytest
@@ -27,7 +28,12 @@ TRACK = "/ws/surveillance/track/test-session"
 
 @pytest.fixture
 def ws_client():
-    return TestClient(create_app())
+    with patch(
+        "flight_blender.websocket.async_read_all_observations",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        yield TestClient(create_app())
 
 
 def _keypair():

--- a/tests/test_websocket_auth.py
+++ b/tests/test_websocket_auth.py
@@ -61,6 +61,7 @@ def auth_enabled(monkeypatch):
 
     monkeypatch.setattr(jb.jwt, "PyJWKClient", _FakeJWKClient)
     monkeypatch.setattr(jb, "settings", _settings(auth_server_jwks_uri="https://jwks.test"))
+    jb._get_jwks_client.cache_clear()
 
     def _token(scope: str = "blender.read blender.write") -> str:
         return jwt.encode(

--- a/tests/test_websocket_auth.py
+++ b/tests/test_websocket_auth.py
@@ -1,0 +1,109 @@
+"""
+WebSocket authentication tests.
+
+The surveillance WebSocket endpoints were unauthenticated: anyone able to reach
+the server could subscribe to any session's heartbeat/track channel. These tests
+pin that, with the auth bypass switched OFF, the handshake is rejected (closed
+before accept) unless a valid bearer token carrying the read scope is supplied
+via the ``token`` query parameter. With the bypass ON (the suite default) the
+connection works without a token, preserving the existing dev/test behaviour.
+"""
+
+import time
+import types
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+import flight_blender.auth.jwt_bearer as jb
+from flight_blender.main import create_app
+
+HEARTBEAT = "/ws/surveillance/heartbeat/test-session"
+TRACK = "/ws/surveillance/track/test-session"
+
+
+@pytest.fixture
+def ws_client():
+    return TestClient(create_app())
+
+
+def _keypair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key, private_key.public_key()
+
+
+def _settings(**overrides):
+    base = dict(
+        bypass_auth_token_verification=False,
+        auth_server_jwks_uri="",
+        auth_audience="",
+        flightblender_read_scope="blender.read",
+        flightblender_write_scope="blender.write",
+    )
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+@pytest.fixture
+def auth_enabled(monkeypatch):
+    """Bypass OFF + JWKS configured with a fake signing key. Returns a token factory."""
+    private_key, public_key = _keypair()
+
+    class _FakeJWKClient:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def get_signing_key_from_jwt(self, _token):
+            return types.SimpleNamespace(key=public_key)
+
+    monkeypatch.setattr(jb.jwt, "PyJWKClient", _FakeJWKClient)
+    monkeypatch.setattr(jb, "settings", _settings(auth_server_jwks_uri="https://jwks.test"))
+
+    def _token(scope: str = "blender.read blender.write") -> str:
+        return jwt.encode(
+            {"exp": int(time.time()) + 3600, "iss": "https://issuer.test", "scope": scope},
+            private_key,
+            algorithm="RS256",
+        )
+
+    return _token
+
+
+def test_heartbeat_rejected_without_token_when_auth_enabled(ws_client, monkeypatch):
+    monkeypatch.setattr(jb, "settings", _settings())
+    with pytest.raises(WebSocketDisconnect):
+        with ws_client.websocket_connect(HEARTBEAT) as ws:
+            ws.receive_json()
+
+
+def test_track_rejected_without_token_when_auth_enabled(ws_client, monkeypatch):
+    monkeypatch.setattr(jb, "settings", _settings())
+    with pytest.raises(WebSocketDisconnect):
+        with ws_client.websocket_connect(TRACK) as ws:
+            ws.receive_json()
+
+
+def test_heartbeat_rejected_with_insufficient_scope(ws_client, auth_enabled):
+    token = auth_enabled(scope="some.other.scope")
+    with pytest.raises(WebSocketDisconnect):
+        with ws_client.websocket_connect(f"{HEARTBEAT}?token={token}") as ws:
+            ws.receive_json()
+
+
+def test_heartbeat_accepted_with_valid_token(ws_client, auth_enabled):
+    token = auth_enabled()
+    with ws_client.websocket_connect(f"{HEARTBEAT}?token={token}") as ws:
+        ws.send_text("auth")  # consumed by _handle_ws_auth so the loop starts promptly
+        data = ws.receive_json()
+        assert "heartbeat_data" in data
+
+
+def test_heartbeat_allowed_without_token_when_bypass_enabled(ws_client):
+    """Suite default: bypass on -> no token required (regression guard)."""
+    with ws_client.websocket_connect(HEARTBEAT) as ws:
+        ws.send_text("auth")
+        data = ws.receive_json()
+        assert "heartbeat_data" in data

--- a/uv.lock
+++ b/uv.lock
@@ -391,7 +391,10 @@ dependencies = [
     { name = "celery" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "http-message-signatures" },
+    { name = "http-sfv" },
     { name = "httpx" },
+    { name = "jwcrypto" },
     { name = "loguru" },
     { name = "pika" },
     { name = "psycopg2-binary" },
@@ -399,6 +402,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "redis" },
     { name = "requests" },
+    { name = "rtree" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
@@ -430,7 +434,10 @@ requires-dist = [
     { name = "celery", specifier = "==5.5.3" },
     { name = "cryptography", specifier = "==46.0.7" },
     { name = "fastapi", specifier = ">=0.116.0" },
+    { name = "http-message-signatures", specifier = ">=0.5.0" },
+    { name = "http-sfv", specifier = ">=0.9.0" },
     { name = "httpx", specifier = "==0.28.1" },
+    { name = "jwcrypto", specifier = ">=1.5.0" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "pika", specifier = "==1.3.2" },
     { name = "psycopg2-binary", specifier = "==2.9.10" },
@@ -438,6 +445,7 @@ requires-dist = [
     { name = "pyjwt", specifier = "==2.12.0" },
     { name = "redis", specifier = "==7.0.1" },
     { name = "requests", specifier = "==2.33.0" },
+    { name = "rtree", specifier = ">=1.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.41" },
     { name = "starlette", specifier = ">=0.47.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
@@ -486,6 +494,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "http-message-signatures"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/95/083707b15af3bdbb6c9e54ae7f448046f7ab55f9eaa5cccdc5dd23791d15/http_message_signatures-2.0.1.tar.gz", hash = "sha256:394545b0cc296a4fd45166f57056e7e029dcd5b91d9bf549e108c96c23aa1cba", size = 30517, upload-time = "2026-01-19T04:01:07.277Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/4a/c778016e3a9c18f283b401319346a980f3ff9556c674afa89a22b9e756bb/http_message_signatures-2.0.1-py3-none-any.whl", hash = "sha256:2b2c463f5d077d3081f27770e8017762d5969a1f17e1dc89e8b96a57c44e8a5e", size = 28204, upload-time = "2026-01-19T04:01:05.738Z" },
+]
+
+[[package]]
+name = "http-sfv"
+version = "0.9.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/ae/7684925d335eb4182d95b2d179c81fc05dbc89dc93e42b239c13f800525c/http_sfv-0.9.9.tar.gz", hash = "sha256:e132dc9bef990832bc01824f5fa9d4efc7d0f4271e4b227db35c8ef38540c739", size = 15973, upload-time = "2024-01-25T05:16:26.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/f7/f5adcd777e7e641c7824f4e45875a14cc7e0c6cd30b0f9db0c3698fd8e16/http_sfv-0.9.9-py3-none-any.whl", hash = "sha256:5feed51c90e9a1dc797701662d044d936923cf0027255c75452b8240e33d6c82", size = 16846, upload-time = "2024-01-25T05:16:24.072Z" },
 ]
 
 [[package]]
@@ -588,6 +620,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/a6/d07afcfdef402900229bcca795f80506b207af13a838d4d99ad45abf530c/jsonpickle-4.1.1.tar.gz", hash = "sha256:f86e18f13e2b96c1c1eede0b7b90095bbb61d99fedc14813c44dc2f361dbbae1", size = 316885, upload-time = "2025-06-02T20:36:11.57Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/73/04df8a6fa66d43a9fd45c30f283cc4afff17da671886e451d52af60bdc7e/jsonpickle-4.1.1-py3-none-any.whl", hash = "sha256:bb141da6057898aa2438ff268362b126826c812a1721e31cf08a6e142910dc91", size = 47125, upload-time = "2025-06-02T20:36:08.647Z" },
+]
+
+[[package]]
+name = "jwcrypto"
+version = "1.5.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/90/f065668004d22715c1940d6e88e4c3afc8ee16d5664e4478d2c8fd23a250/jwcrypto-1.5.7.tar.gz", hash = "sha256:70204d7cca406eda8c82352e3c41ba2d946610dafd19e54403f0a1f4f18633c6", size = 89535, upload-time = "2026-04-07T00:35:36.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/24/fb7da4d6613de7001feaf540d4b5969c6b5a1c42839043b0196cb13aa057/jwcrypto-1.5.7-py3-none-any.whl", hash = "sha256:729463fefe28b6de5cf1ebfda3e94f1a1b41d2799148ef98a01cb9678ebe2bb0", size = 94799, upload-time = "2026-04-07T00:35:35.085Z" },
 ]
 
 [[package]]
@@ -1066,6 +1111,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rtree"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/09/7302695875a019514de9a5dd17b8320e7a19d6e7bc8f85dcfb79a4ce2da3/rtree-1.4.1.tar.gz", hash = "sha256:c6b1b3550881e57ebe530cc6cffefc87cd9bf49c30b37b894065a9f810875e46", size = 52425, upload-time = "2025-08-13T19:32:01.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d9/108cd989a4c0954e60b3cdc86fd2826407702b5375f6dfdab2802e5fed98/rtree-1.4.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d672184298527522d4914d8ae53bf76982b86ca420b0acde9298a7a87d81d4a4", size = 468484, upload-time = "2025-08-13T19:31:50.593Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/cf/2710b6fd6b07ea0aef317b29f335790ba6adf06a28ac236078ed9bd8a91d/rtree-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7e48d805e12011c2cf739a29d6a60ae852fb1de9fc84220bbcef67e6e595d7d", size = 436325, upload-time = "2025-08-13T19:31:52.367Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e1/4d075268a46e68db3cac51846eb6a3ab96ed481c585c5a1ad411b3c23aad/rtree-1.4.1-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa8c4496e31e9ad58ff6c7df89abceac7022d906cb64a3e18e4fceae6b77f65", size = 459789, upload-time = "2025-08-13T19:31:53.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/75/e5d44be90525cd28503e7f836d077ae6663ec0687a13ba7810b4114b3668/rtree-1.4.1-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12de4578f1b3381a93a655846900be4e3d5f4cd5e306b8b00aa77c1121dc7e8c", size = 507644, upload-time = "2025-08-13T19:31:55.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/85/b8684f769a142163b52859a38a486493b05bafb4f2fb71d4f945de28ebf9/rtree-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b558edda52eca3e6d1ee629042192c65e6b7f2c150d6d6cd207ce82f85be3967", size = 1454478, upload-time = "2025-08-13T19:31:56.808Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## FastAPI migration — restore dropped / weakened behaviour

Restores safety- and security-critical behaviour that was lost or weakened in the Django → FastAPI migration, working from a detailed app-by-app review of the `fastapi` branch. **Draft**, grown incrementally — each concern is its own test-driven commit (failing test first, then the fix).

**Base:** `fastapi` · every change is TDD; the full suite stays green — currently **458 passing** (up from 259 at branch point), all `ruff`/`codespell` gates clean, the Alembic chain is linear (single head), and `alembic upgrade head`/`downgrade base` both verified. **All 13 reviewed apps + the shared/cross-cutting layer now have a fix commit.**

### Shared / cross-cutting

- [x] **`fix(auth)` — harden JWT verification to the Django posture** (`bd0c69d`) — fail-open → fail-closed when JWKS unset; `AUTH_AUDIENCE` enforced (`audience=` + require `aud`); `exp`/`iss` required-present; extracted `verify_bearer_token()` (also backs the WS gate). Real non-bypassed RS256 tests.
- [x] **`feat(common)` — restore operational-intent state-set invariants** (`c9baf85`) — `VALID_OPERATIONAL_INTENT_STATES` `[1,2,3,4]` + `ACTIVE_OPERATIONAL_STATES` `[2,3,4]` as typed `frozenset[OperationState]`.
- [x] **`fix(deploy)` — enable Celery beat in the prod compose** (`a209496`) — re-enabled `flight-blender-celery-beat` (was commented out → no scheduled task ran); fixed stale image name; compose-parsing test.
- [x] **`fix(ws)` — authenticate WebSocket handshakes** (`5e9f5d8`) — `_authorize_ws()` verifies `?token=` + read scope before accept; closes with `1008`; honors the bypass.

### Per app

- [x] **`feat(conformance)` — real C2–C11 engine + scheduling** (`4cea2da`) — ported the ASTM F3548-21 checks from the Django engine into `services/conformance_engine.py`; `tasks/conformance.py` calls the real engine + a `check_all_flight_conformance` dispatcher; added a `periodic-conformance-check` beat entry. (+29 tests; the ASTM state machine already existed.)
- [x] **`feat(deconfliction)` — strategic deconfliction for flight_declaration + SCD** (`cf59366`) — real 4D engine (space ∧ time ∧ altitude; pure-Python; Django bbox/R-tree fallback); `_run_deconfliction` fails closed; `_maybe_submit_to_dss` restores the `USSP_NETWORK_ENABLED` gate; SCD computes a real ASTM planning result. (+45 tests.)
- [x] **`feat(rid)` — peer-USS interop, signed-telemetry, schema fidelity** (`636c0ee`) — `/uss/flights` at the Django path under `rid.display_provider`; telemetry verifier body-bound; `view_hash` nullable + Django indexes (Alembic `rid001`). (+24 tests.)
- [x] **`feat(flight_feed)` — ingestion notifications + index `session_id`** (`78b7cde`) — enqueue `send_operational_update_message` on ingest (no-op without `AMQP_URL`); `session_id` index (Alembic `ff001`). (+5 tests.)
- [x] **`fix(weather)` — Django parity** (`d507c4e`) — scope write→`WriteDep`; restored the dropped `time` param + the full response shape; non-leaking 502. (+13 tests.)
- [x] **`feat(geo_fence)` — geo-awareness scope, geozone parsing, source lifecycle, map/queries** (`0b4c743`) — restored the `geo-awareness.test` scope; ED-269 parsing + real bounds; `PUT` source lifecycle; ED-269 `map/queries`; test-dataset filtering. (+35 tests.)
- [x] **`feat(surveillance)` — `get_air_traffic` GET + real SDSP heartbeat metrics** (`8371d73`) — restored the GET; `compute_sdsp_heartbeat()` derives real latency/accuracy + SLA from the stream (was hardcoded always-healthy). (+6 tests.)
- [x] **`feat(notification)` — persist on the no-AMQP path** (`b0241da`) — `send_operational_update_message` no longer silently drops when `AMQP_URL` is unset: it persists via a DI `create_operator_rid_notification()`; `session_id` nullable (Alembic `nt001`). (+5 tests.)
- [x] **`constraint` — review finding was stale; pinned read endpoints with tests** (`f5fa956`) — ⚠️ *the commit subject overstates it (its diff is `tests/test_constraint.py` only).* Re-verifying the Django source showed the `constraint_operations` app exposes **no HTTP endpoints** (empty `urls.py`/`views.py`; only DSS *read* helpers), so the review's `POST /query` + DSS-coordination claims describe behaviour that never existed to migrate. FastAPI's `/constraint_ops` reads are additive with good model parity; pinned with characterization tests (shapes incl. `_type`→`type`, 404s, invalid-uuid 422). **+5 tests, no production change.** Constraint↔DSS coordination would be a *new feature*, not a migration fix.
- [x] **`feat(utm_adapter)` — peer-USS client + DSS OVN/key/extents builders** (`b2e8434`) — added (HTTP layer mocked in tests): `get_peer_operational_intent_details()` (auth GET `/uss/v1/operational_intents/{id}` → volumes), a `USSP_NETWORK_ENABLED`-gated peer-notification builder, and pure `extract_ovns()` / `build_extents_from_volumes()` / `build_operational_intent_reference_payload()`. **+14 tests.** (Wired into the op-intent submission task in `5994acb` below.)
- [x] **`fix(daa)` — reject malformed date filters with 422** (`47aa61b`, test fix `7e66ba2`, constant cleanup `1f7ea00`) — `_filter_incident_query` parsed `start_date`/`end_date` with `except ValueError: pass` (client got unfiltered results, no error); now parses strictly → `422`. (+2 tests; updated one stale lenient-date test.) DAA was otherwise a clean additive port.

### Remaining follow-ups (documented; need a live DSS/peer or a schema migration)

For the DSS/peer items the **decision/payload/build logic is implemented and unit-tested**; only the raw network round-trip remains, behind the `USSP_NETWORK_ENABLED` gate + DSS token helper:

- [ ] **Populate the airspace `key`** in `submit_flight_declaration_to_dss_async` from a live DSS area query of overlapping op-intent references (extents are now wired in `5994acb`; `key` still needs the area-query round-trip + OVN collection via the tested `collect_ovns()`).
- [ ] **Conformance enforcement loop** — DSS state-transition automation (the 5 Django management commands) + signal-style auto-transition of misbehaving ops to nonconforming/contingent + operator notify. (The C2–C11 engine, scheduling, and the notification persistence creator already landed.)
- [ ] **`ConformanceRecord` schema restoration** (`timestamp`, geofence FK, state choices) — needs an Alembic migration.
- [ ] **Live DSS/peer-USS round-trips** — op-intent submission, peer op-intent GET, peer notify.
- [ ] **Cross-process WebSocket fan-out** (Redis channel layer) for multi-worker delivery.
- [ ] Minor: geo_fence response JSON-decoding of `raw_geo_fence`/`geozone`; surveillance metric persistence; constraint display-string serializers.

A full written review (`FASTAPI_MIGRATION_REVIEW.md`) backs this work; each finding was re-verified against current `HEAD` before its fix. Several review items were already addressed on `fastapi` (the ASTM state machine, the telemetry-verifier scaffold, `ussp_network_enabled`/`auth_audience` config), and one (constraint) turned out to be a stale finding.
