### PR TITLE
Improve InterUSS F3548 and NetRID qualification

### DIFF
--- a/.claude/skills/interuss-analysis/SKILL.md
+++ b/.claude/skills/interuss-analysis/SKILL.md
@@ -1,0 +1,293 @@
+---
+description: Analyze interUSS qualification failures, run the qualifier locally with Docker, and debug Flight Blender issues against ASTM F3548-21 and NetRID F3411-22a.
+---
+
+# Analyze interUSS Qualification Problems
+
+Flight Blender is tested against the [interUSS uss_qualifier](https://github.com/interuss/monitoring) which validates ASTM F3548-21 (SCD) and F3411-22a (NetRID) compliance. This skill covers running the qualifier locally, interpreting results, and debugging failures.
+
+## Assumptions
+
+- Docker running with ~8 GB RAM available
+- Working directory is the **flight-blender repo root** unless noted
+- The `interuss/monitoring` repo is cloned to `/tmp/interuss-monitoring` (the run script handles this)
+- macOS Apple Silicon: the interuss containers are linux/amd64 and run via Rosetta
+
+---
+
+## 1. Run the full qualifier locally
+
+The all-in-one script handles everything: builds the image, starts the DSS ecosystem, starts Flight Blender, starts mock USS instances, runs both test suites, and tears down.
+
+```bash
+bash testing/interuss/scripts/run_interuss_tests.sh
+```
+
+Options:
+- `--skip-build` — reuse the existing Docker image (faster iteration)
+- `--clean` — remove all test containers and networks before starting
+
+Reports land in `testing/interuss/output/`:
+```
+testing/interuss/output/
+  f3548/
+    report.json                     # raw JSON — all participants, all checks
+    sequence/                       # HTML sequence view (index.html + s1.html .. s64.html)
+    f3548_requirements/             # HTML per-requirement breakdown
+  netrid_v22a/
+    report.json
+    sequence/
+    netrid_v22a_requirements/
+```
+
+Open the sequence view in a browser:
+```bash
+open testing/interuss/output/f3548/sequence/index.html
+```
+
+---
+
+## 2. Run steps manually (for iteration)
+
+If you want to iterate on code changes without running the full script:
+
+### 2a. Start the DSS ecosystem
+
+```bash
+cd /tmp/interuss-monitoring
+NUM_USS=2 ./build/dev/run_locally.sh up -d
+```
+
+Wait for OAuth:
+```bash
+for i in $(seq 1 60); do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:8085/ 2>/dev/null || echo "000")
+  [ "$STATUS" != "000" ] && echo "OAuth ready" && break
+  sleep 3
+done
+```
+
+### 2b. Build and start Flight Blender
+
+```bash
+docker build -t openutm/flight-blender-test:latest .
+docker compose -f testing/interuss/docker-compose.yml up -d
+```
+
+Wait for Flight Blender:
+```bash
+for i in $(seq 1 90); do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:8000/scd/flight_planning/status 2>/dev/null || echo "000")
+  [ "$STATUS" != "000" ] && echo "Flight Blender ready (HTTP $STATUS)" && break
+  sleep 3
+done
+```
+
+### 2c. Start mock USS instances
+
+```bash
+cd /tmp/interuss-monitoring
+docker compose -f monitoring/mock_uss/docker-compose.yaml up -d \
+  mock_uss_scdsc_a mock_uss_scdsc_b mock_uss_scdsc_interaction_log \
+  mock_uss_ridsp mock_uss_riddp
+sleep 10
+```
+
+### 2d. Run only F3548 (skip NetRID for faster iteration)
+
+```bash
+docker run --rm \
+  --network interop_ecosystem_network \
+  --add-host "host.docker.internal:host-gateway" \
+  -w /app/monitoring/uss_qualifier \
+  -e "AUTH_SPEC=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)" \
+  -e "AUTH_SPEC_2=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier_2)" \
+  -v "$(pwd)/testing/interuss/configs:/configs:ro" \
+  -v "$(pwd)/testing/interuss/output:/app/monitoring/uss_qualifier/output" \
+  interuss/monitoring:v0.30.0 \
+  uv run main.py \
+    --config "file:///configs/f3548_flight_blender.yaml" \
+    --output-path "output/f3548"
+```
+
+### 2e. Tear down
+
+```bash
+docker compose -f testing/interuss/docker-compose.yml down --remove-orphans
+cd /tmp/interuss-monitoring
+docker compose -f monitoring/mock_uss/docker-compose.yaml down --remove-orphans
+NUM_USS=2 ./build/dev/run_locally.sh down
+```
+
+---
+
+## 3. Understand the results table
+
+Open `testing/interuss/output/f3548/sequence/index.html` in a browser.
+
+### Participant columns
+
+Each column is a system instance being tested simultaneously:
+
+| Column | What it is | Why it's tested |
+|--------|-----------|-----------------|
+| `flight_blender` | Your Flight Blender instance | System under test |
+| `mock_uss` | interuss mock_uss (subscription callbacks, notifications) | Validates notification delivery works |
+| `uss1_dss` | First DSS (`dss1.uss1.localutm`) | Validates DSS that Flight Blender depends on |
+| `uss2_core` | Peer USS (`scdsc.uss2.localutm`) | Reference implementation — baseline comparison |
+| `uss2_dss` | Second DSS (`dss1.uss2.us2.localutm`) | Validates cross-DSS interoperability |
+| `<None>` | Global/aggregate tests | Tests that don't belong to a specific participant |
+
+### How to read a row
+
+For each test case (row), each cell shows:
+- ✅ `pass_result` — participant passed
+- ❌ `fail_result` — participant failed
+- (empty) — not applicable to that participant
+
+### What matters for Flight Blender debugging
+
+**Focus on the `flight_blender` column.** When:
+- `flight_blender` = ❌ and other columns = ✅ → the bug is in Flight Blender specifically
+- `flight_blender` = ❌ and DSS columns = ❌ → likely an infrastructure/DSS issue
+- `flight_blender` = ✅ and others = ❌ → Flight Blender is fine, peer implementation is broken
+
+---
+
+## 4. Read the HTML sequence reports
+
+Each `s{N}.html` file shows the detailed request/response for one test scenario.
+
+Key elements to look for:
+- **Request URL and method** — which endpoint was called
+- **Request body** — what was sent (flight intent, area, time range)
+- **Response code** — 200, 400, 404, 500, etc.
+- **Response body** — the actual response JSON
+- **Failed check** — the `failed_check_summary` and `failed_check_details` text
+
+Example failure pattern:
+```
+failed_check_summary: Flight planning activity PlanningActivityResult.Failed
+failed_check_details: flight_blender indicated PlanningActivityResult.Failed
+  leaving flight plan FlightPlanStatus.NotPlanned rather than the expected
+  (Activity Completed, flight plan Planned)
+```
+
+This tells you: Flight Blender returned `Failed` when it should have returned `Completed` with the flight planned.
+
+---
+
+## 5. Common failure categories
+
+### A. Missing endpoint (404)
+
+**Symptom:** `GET /versioning/versions/astm.f3548.v21` returns 404.
+**Fix:** Implement the endpoint returning `{"system_identity": "<id>", "system_version": "<ver>"}`.
+
+### B. Flight planning returns `Failed` instead of `Rejected`/`Completed`
+
+**Symptom:** `PUT /scd/flight_planning/flight_plans/{id}` returns:
+```json
+{"flight_plan_status": "NotPlanned", "planning_result": "Failed",
+ "notes": "Flight Blender failed to process this flight"}
+```
+**Root cause:** The flight planning handler crashes before evaluating the conflict.
+**Debug:**
+1. Check Flight Blender logs: `docker logs flight-blender-test 2>&1 | tail -100`
+2. Look for Python tracebacks around the time of the request
+3. Common causes: missing DSS query, malformed flight intent conversion, missing deconfliction wiring
+
+### C. DSS not publicly addressable
+
+**Symptom:** `DSS host dss1.uss1.localutm is not publicly addressable` (resolved IP 172.18.0.x).
+**Root cause:** Docker-internal hostname not routable from the qualifier container.
+**Fix:** Infrastructure/DNS configuration, not a code issue.
+
+### D. Rejection reasons not structured
+
+**Symptom:** Flight Blender rejects a flight but doesn't include the structured `rejection` field the qualifier expects.
+**Fix:** Return proper rejection details in the response body with `result` enum values like `ConflictFlightTested`, `ConflictOther`.
+
+---
+
+## 6. Debug with container logs
+
+Flight Blender logs (last 5000 lines per container):
+```bash
+docker logs flight-blender-test 2>&1 | tail -100
+docker logs celery-blender-test 2>&1 | tail -50
+```
+
+Search for errors:
+```bash
+docker logs flight-blender-test 2>&1 | grep -i "error\|exception\|traceback" | tail -20
+```
+
+DSS logs (for DSS-related failures):
+```bash
+# Find DSS container name
+docker ps --format '{{.Names}}' | grep dss
+# Then check its logs
+docker logs <dss-container> 2>&1 | tail -50
+```
+
+Query the DB directly:
+```bash
+docker exec db-blender-test psql -U testuser -d testdb \
+  -c "SELECT tablename FROM pg_tables WHERE tablename LIKE 'operational%' ORDER BY tablename;"
+```
+
+---
+
+## 7. CI workflow logs
+
+The GitHub Actions workflow saves structured logs as artifacts:
+
+1. Go to the Actions run → Artifacts section
+2. Download `interuss-container-logs-{run_number}`
+3. Each container has `.log` (raw) and `.jsonl` (structured) files
+
+The JSONL format — each line is:
+```json
+{"ts": "2026-06-05T23:41:18.219502Z", "service": "flight-blender-test", "msg": "INFO ..."}
+```
+
+Filter by service and timestamp to trace a specific request:
+```bash
+cat flight-blender-test.jsonl | python3 -c "
+import json, sys
+for line in sys.stdin:
+    e = json.loads(line)
+    if '2026-06-05T23:41:4' in e['ts']:
+        print(e['msg'])
+"
+```
+
+---
+
+## 8. Config overview
+
+The qualifier config is at `testing/interuss/configs/f3548_flight_blender.yaml`.
+
+Key sections:
+- `flight_planners` — defines Flight Blender and mock_uss as flight planners
+- `dss` / `dss_instances` — DSS endpoints
+- `conflicting_flights` / `non_conflicting_flights` — test flight intents with geographic translation
+- `invalid_flight_intents` — flights that should be rejected (too far away, recently ended, tiny overlap)
+- `artifacts.sequence_view` — generates the HTML sequence report
+
+---
+
+## Quick reference
+
+| What | Command |
+|------|---------|
+| Run full qualifier locally | `bash testing/interuss/scripts/run_interuss_tests.sh` |
+| Run with existing image | `bash testing/interuss/scripts/run_interuss_tests.sh --skip-build` |
+| Clean everything first | `bash testing/interuss/scripts/run_interuss_tests.sh --clean` |
+| Open sequence report | `open testing/interuss/output/f3548/sequence/index.html` |
+| Flight Blender logs | `docker logs flight-blender-test 2>&1 \| tail -100` |
+| Search for errors | `docker logs flight-blender-test 2>&1 \| grep -i error \| tail -20` |
+| DSS container name | `docker ps --format '{{.Names}}' \| grep dss` |
+| DB table names | `docker exec db-blender-test psql -U testuser -d testdb -c "SELECT tablename FROM pg_tables;"` |
+| Tear down all | `docker compose -f testing/interuss/docker-compose.yml down --remove-orphans && (cd /tmp/interuss-monitoring && NUM_USS=2 ./build/dev/run_locally.sh down)` |

--- a/.github/scripts/pr-comment.js
+++ b/.github/scripts/pr-comment.js
@@ -1,0 +1,89 @@
+async function findPrComment({ github, owner, repo, issueNumber, marker }) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+
+  return comments.find(
+    comment => comment.user.type === 'Bot' && comment.body.includes(marker)
+  );
+}
+
+async function upsertPrComment({
+  github,
+  context,
+  marker,
+  body,
+  owner = context.repo.owner,
+  repo = context.repo.repo,
+  issueNumber = context.issue.number,
+}) {
+  if (!issueNumber) {
+    throw new Error('issueNumber is required to update a PR comment');
+  }
+
+  const existing = await findPrComment({
+    github,
+    owner,
+    repo,
+    issueNumber,
+    marker,
+  });
+
+  if (existing) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body,
+    });
+    return existing.id;
+  }
+
+  const created = await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body,
+  });
+  return created.data.id;
+}
+
+async function deletePrComment({
+  github,
+  context,
+  marker,
+  owner = context.repo.owner,
+  repo = context.repo.repo,
+  issueNumber = context.issue.number,
+}) {
+  if (!issueNumber) {
+    throw new Error('issueNumber is required to delete a PR comment');
+  }
+
+  const existing = await findPrComment({
+    github,
+    owner,
+    repo,
+    issueNumber,
+    marker,
+  });
+
+  if (!existing) {
+    return false;
+  }
+
+  await github.rest.issues.deleteComment({
+    owner,
+    repo,
+    comment_id: existing.id,
+  });
+  return true;
+}
+
+module.exports = {
+  deletePrComment,
+  upsertPrComment,
+};

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -135,6 +136,8 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = ':bar_chart: Test Coverage Report';
             const total = '${{ steps.metrics.outputs.total_coverage }}';
             const exitCode = '${{ steps.coverage.outputs.exit_code }}';
 
@@ -172,27 +175,7 @@ jobs:
               }
             }
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':bar_chart: Test Coverage Report'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await upsertPrComment({ github, context, marker, body });
       - name: Fail if tests failed
         if: steps.coverage.outputs.exit_code != '0'
         run: exit 1
@@ -267,6 +250,8 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = ':brain: Code Complexity Report';
             const avg = '${{ steps.cc.outputs.average }}';
             const highCount = parseInt('${{ steps.cc.outputs.high_count }}' || '0');
             const lowMI = parseInt('${{ steps.mi.outputs.low_mi_count }}' || '0');
@@ -290,24 +275,4 @@ jobs:
               body += '</details>\n';
             }
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':brain: Code Complexity Report'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await upsertPrComment({ github, context, marker, body });

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   security-events: write
   pull-requests: write
 
@@ -62,6 +63,8 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = ':whale: Trivy Container Scan';
             const outcome = '${{ steps.trivy.outcome }}';
             let body = '## :whale: Trivy Container Scan\n\n';
             if (outcome === 'success') {
@@ -75,27 +78,7 @@ jobs:
               body += '```\n' + report + '\n```\n';
               body += '</details>';
             }
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':whale: Trivy Container Scan'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await upsertPrComment({ github, context, marker, body });
       - name: Generate SBOM
         if: always()
         uses: anchore/sbom-action@v0.24.0

--- a/.github/workflows/interuss-qualification.yml
+++ b/.github/workflows/interuss-qualification.yml
@@ -267,6 +267,16 @@ jobs:
           retention-days: 30
 
       # -------------------------------------------------------
+      - name: Upload container logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: interuss-container-logs-${{ github.run_number }}
+          path: testing/interuss/output/logs/
+          if-no-files-found: warn
+          retention-days: 30
+
+      # -------------------------------------------------------
       - name: Post PR comment with qualification report
         if: always()
         uses: actions/github-script@v7
@@ -368,15 +378,53 @@ jobs:
             }
 
       # -------------------------------------------------------
-      - name: Collect container logs on failure
-        if: failure()
+      - name: Collect container logs (JSONL per service)
+        if: always()
         run: |
-          echo "=== Flight Blender logs ==="
-          docker logs flight-blender-test 2>&1 | tail -100 || true
-          echo "=== Celery logs ==="
-          docker logs celery-blender-test 2>&1 | tail -50 || true
-          echo "=== DB logs ==="
-          docker logs db-blender-test 2>&1 | tail -30 || true
+          LOG_DIR="testing/interuss/output/logs"
+          mkdir -p "$LOG_DIR"
+
+          collect_logs() {
+            local container="$1"
+            local raw_file="$LOG_DIR/${container}.log"
+            local jsonl_file="$LOG_DIR/${container}.jsonl"
+
+            if ! docker inspect "$container" >/dev/null 2>&1; then
+              printf '{"ts":"%s","service":"%s","msg":"container not found"}\n' \
+                "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" "$container" > "$jsonl_file"
+              return
+            fi
+
+            docker logs "$container" > "$raw_file" 2>&1 || true
+
+            python3 - "$container" < "$raw_file" > "$jsonl_file" \
+              -c 'import json,re,sys;from datetime import datetime,timezone;
+              svc=sys.argv[1];pat=re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)\s+(.*)");
+              [print(json.dumps({"ts":((m:=pat.match(l)).group(1) if m else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")),
+              "service":svc,"msg":(m.group(2) if m else l)})) for l in map(str.rstrip,sys.stdin) if l]' \
+              || true
+
+            local count
+            count=$(wc -l < "$jsonl_file" 2>/dev/null || echo 0)
+            echo "  ${container}: ${count} lines"
+          }
+
+          echo "=== Collecting container logs ==="
+
+          # Flight Blender stack
+          collect_logs "flight-blender-test"
+          collect_logs "celery-blender-test"
+          collect_logs "db-blender-test"
+          collect_logs "redis-blender-test"
+
+          # InterUSS ecosystem — discover container names dynamically
+          for c in $(docker ps --format '{{.Names}}' | grep -iE '(dss|oauth|cockroach|mock_uss|scdsc|log)'); do
+            collect_logs "$c"
+          done
+
+          echo ""
+          echo "=== Log files ==="
+          ls -lh "$LOG_DIR/"
 
       # -------------------------------------------------------
       - name: Tear down test containers

--- a/.github/workflows/interuss-qualification.yml
+++ b/.github/workflows/interuss-qualification.yml
@@ -24,6 +24,8 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: read
 
 jobs:
   interuss-qualification:
@@ -45,12 +47,37 @@ jobs:
           key: interuss-monitoring-v0.30.0
 
       - name: Run InterUSS qualification
+        env:
+          INTERUSS_SUMMARY_FILE: testing/interuss/output/interuss-summary.md
         run: |
           args=(--clean)
           if [ "${INTERUSS_SUITE}" != "both" ]; then
             args+=(--suite "${INTERUSS_SUITE}")
           fi
           bash testing/interuss/scripts/run_interuss_tests.sh "${args[@]}"
+
+      - name: Update PR report comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = '<!-- interuss-qualification-report -->';
+            const summaryPath = 'testing/interuss/output/interuss-summary.md';
+            const summary = fs.existsSync(summaryPath)
+              ? fs.readFileSync(summaryPath, 'utf8').trim()
+              : '_No InterUSS report summary was generated._';
+            const body = [
+              marker,
+              '# InterUSS Qualification Report',
+              '',
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              summary,
+            ].join('\n');
+
+            await upsertPrComment({ github, context, marker, body });
 
       - name: Upload qualification reports
         if: always()

--- a/.github/workflows/interuss-qualification.yml
+++ b/.github/workflows/interuss-qualification.yml
@@ -385,7 +385,7 @@ jobs:
               return
             fi
 
-            docker logs "$container" > "$raw_file" 2>&1 || true
+            docker logs "$container" 2>&1 | tail -5000 > "$raw_file" || true
 
             python3 -c '
             import json,re,sys
@@ -413,11 +413,6 @@ jobs:
           collect_logs "celery-blender-test"
           collect_logs "db-blender-test"
           collect_logs "redis-blender-test"
-
-          # InterUSS ecosystem — discover container names dynamically
-          for c in $(docker ps --format '{{.Names}}' | grep -iE '(dss|oauth|cockroach|mock_uss|scdsc|log)'); do
-            collect_logs "$c"
-          done
 
           echo ""
           echo "=== Log files ==="

--- a/.github/workflows/interuss-qualification.yml
+++ b/.github/workflows/interuss-qualification.yml
@@ -1,55 +1,29 @@
 name: InterUSS Qualification
 
 on:
-  # Manual trigger — run on demand from the Actions UI
-  workflow_dispatch:
-    inputs:
-      skip_netrid:
-        description: "Skip NetRID v22a test suite"
-        type: boolean
-        default: false
-
-  # Run automatically on pushes that touch the relevant code
+  pull_request:
   push:
     branches:
       - main
-      - "feat/issue-95-*"
-    paths:
-      - "rid_operations/**"
-      - "scd_operations/**"
-      - "auth_helper/**"
-      - "conformance_monitoring_operations/**"
-      - "constraint_operations/**"
-      - "testing/interuss/**"
-      - ".github/workflows/interuss-qualification.yml"
-
-  # Run automatically on pull requests targeting relevant branches
-  pull_request:
-    branches:
-      - main
-      - "feat/issue-95-*"
-    paths:
-      - "rid_operations/**"
-      - "scd_operations/**"
-      - "auth_helper/**"
-      - "conformance_monitoring_operations/**"
-      - "constraint_operations/**"
-      - "testing/interuss/**"
-      - ".github/workflows/interuss-qualification.yml"
-
-  # Nightly run to catch regressions early
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: "InterUSS suite to run"
+        type: choice
+        options:
+          - both
+          - f3548
+          - netrid
+        default: both
   schedule:
-    - cron: "0 3 * * 1"  # 03:00 UTC every Monday
+    - cron: "0 3 * * 1"
 
-# Limit concurrency: only one qualification run at a time per branch
 concurrency:
   group: interuss-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   interuss-qualification:
@@ -58,200 +32,27 @@ jobs:
     timeout-minutes: 90
 
     env:
-      INTERUSS_TAG: interuss/monitoring/v0.30.0
-      INTERUSS_IMAGE: interuss/monitoring:v0.30.0
-      NETWORK: interop_ecosystem_network
-      AUTH_SPEC: "DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)"
-      AUTH_SPEC_2: "DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier_2)"
+      INTERUSS_SUITE: ${{ github.event_name == 'workflow_dispatch' && inputs.suite || 'both' }}
 
     steps:
-      # -------------------------------------------------------
-      - name: Checkout flight-blender
+      - name: Checkout
         uses: actions/checkout@v4
 
-      # -------------------------------------------------------
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # -------------------------------------------------------
-      - name: Create Docker networks
-        run: |
-          # interop_ecosystem_network: plain bridge, no subnet (run_locally.sh attaches to this)
-          docker network create "$NETWORK" || true
-          # dss_internal_network needs a specific subnet for CockroachDB static IPs
-          docker network create \
-            --subnet=172.27.0.0/16 \
-            --ip-range=172.27.0.0/24 \
-            --gateway=172.27.0.1 \
-            dss_internal_network || true
-
-      # -------------------------------------------------------
       - name: Cache interuss/monitoring clone
         uses: actions/cache@v4
         with:
           path: /tmp/interuss-monitoring
-          key: interuss-monitoring-${{ env.INTERUSS_TAG }}
+          key: interuss-monitoring-v0.30.0
 
-      - name: Clone interuss/monitoring
+      - name: Run InterUSS qualification
         run: |
-          if [ ! -d /tmp/interuss-monitoring/.git ]; then
-            git clone --depth=1 --branch "$INTERUSS_TAG" \
-              https://github.com/interuss/monitoring.git \
-              /tmp/interuss-monitoring
-          else
-            echo "Using cached clone."
+          args=(--clean)
+          if [ "${INTERUSS_SUITE}" != "both" ]; then
+            args+=(--suite "${INTERUSS_SUITE}")
           fi
+          bash testing/interuss/scripts/run_interuss_tests.sh "${args[@]}"
 
-      # -------------------------------------------------------
-      - name: Pull interuss/monitoring Docker image
-        run: docker pull "$INTERUSS_IMAGE"
-
-      # -------------------------------------------------------
-      - name: Start DSS ecosystem (CockroachDB + DSS + dummy OAuth)
-        run: |
-          cd /tmp/interuss-monitoring
-          NUM_USS=2 ./build/dev/run_locally.sh up -d
-          echo "Waiting for dummy OAuth to be ready..."
-          # dummy-oauth does NOT expose /.well-known/jwks.json (returns 404)
-          # so we check for any HTTP response on port 8085 instead
-          for i in $(seq 1 60); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
-              "http://localhost:8085/" 2>/dev/null || echo "000")
-            if [ "$STATUS" != "000" ]; then
-              echo "dummy-oauth is ready (HTTP $STATUS)."
-              break
-            fi
-            [ "$i" -eq 60 ] && echo "ERROR: dummy-oauth did not start in time." && exit 1
-            sleep 3
-          done
-
-      # -------------------------------------------------------
-      - name: Build Flight Blender Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: false
-          load: true
-          tags: openutm/flight-blender-test:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # -------------------------------------------------------
-      - name: Start Flight Blender stack
-        run: |
-          docker compose -f testing/interuss/docker-compose.yml up -d
-          echo "Waiting for Flight Blender to start..."
-          # Poll the flight planning status endpoint; 401/400 = app is up but not authed
-          for i in $(seq 1 90); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-              --max-time 5 \
-              "http://localhost:8000/scd/flight_planning/status" 2>/dev/null || echo "000")
-            if [ "$STATUS" != "000" ]; then
-              echo "Flight Blender responded with HTTP $STATUS — app is up."
-              break
-            fi
-            [ "$i" -eq 90 ] && echo "WARNING: Flight Blender did not respond after 90 attempts." && break
-            sleep 3
-          done
-
-      # -------------------------------------------------------
-      - name: Start mock USS instances
-        run: |
-          cd /tmp/interuss-monitoring
-          # Start the mock_uss services needed for F3548 and NetRID v22a:
-          #   scdsc_a, scdsc_b, scdsc_interaction_log: SCD flight planning
-          #   v22a_ridsp_uss1: RID v22a service provider (for interaction tests)
-          #   v22a_riddp_uss1: RID v22a display provider (observer)
-          docker compose \
-            -f monitoring/mock_uss/docker-compose.yaml \
-            up -d \
-            mock_uss_scdsc_a mock_uss_scdsc_b mock_uss_scdsc_interaction_log \
-            mock_uss_ridsp mock_uss_riddp \
-            2>/dev/null || \
-          echo "WARNING: mock_uss startup had issues; continuing anyway."
-          sleep 15
-
-      # -------------------------------------------------------
-      - name: Prepare output directory
-        run: |
-          mkdir -p testing/interuss/output
-          # The output directory is mounted into the uss_qualifier container
-          # so it needs to be world-writable (uss_qualifier runs as non-root)
-          chmod 777 testing/interuss/output
-
-      # -------------------------------------------------------
-      - name: Run uss_qualifier — F3548-21 (Strategic Conflict Detection)
-        id: f3548
-        continue-on-error: true
-        run: |
-          docker run --rm \
-            --network "$NETWORK" \
-            --add-host "host.docker.internal:host-gateway" \
-            -w /app/monitoring/uss_qualifier \
-            -e "AUTH_SPEC=$AUTH_SPEC" \
-            -e "AUTH_SPEC_2=$AUTH_SPEC_2" \
-            -v "${{ github.workspace }}/testing/interuss/configs:/configs:ro" \
-            -v "${{ github.workspace }}/testing/interuss/output:/app/monitoring/uss_qualifier/output" \
-            "$INTERUSS_IMAGE" \
-            uv run main.py \
-              --config "file:///configs/f3548_flight_blender.yaml" \
-              --output-path "output/f3548"
-
-      # -------------------------------------------------------
-      - name: Run uss_qualifier — NetRID v22a (F3411-22a)
-        id: netrid_v22a
-        if: ${{ !inputs.skip_netrid }}
-        continue-on-error: true
-        run: |
-          docker run --rm \
-            --network "$NETWORK" \
-            --add-host "host.docker.internal:host-gateway" \
-            -w /app/monitoring/uss_qualifier \
-            -e "AUTH_SPEC=$AUTH_SPEC" \
-            -v "${{ github.workspace }}/testing/interuss/configs:/configs:ro" \
-            -v "${{ github.workspace }}/testing/interuss/output:/app/monitoring/uss_qualifier/output" \
-            "$INTERUSS_IMAGE" \
-            uv run main.py \
-              --config "file:///configs/netrid_v22a_flight_blender.yaml" \
-              --output-path "output/netrid_v22a"
-
-      # -------------------------------------------------------
-      - name: Generate GitHub Step Summary
-        if: always()
-        run: |
-          {
-            echo "# InterUSS Qualification Report"
-            echo ""
-            echo "_Commit: \`${{ github.sha }}\` | Branch: \`${{ github.ref_name }}\`_"
-            echo ""
-
-            F3548_RC="${{ steps.f3548.outcome }}"
-            NETRID_RC="${{ steps.netrid_v22a.outcome }}"
-
-            if [ "$F3548_RC" = "success" ]; then
-              echo "**F3548-21:** ✅ uss_qualifier completed"
-            else
-              echo "**F3548-21:** ⚠️ uss_qualifier finished with failures (see report)"
-            fi
-
-            if [ "${{ inputs.skip_netrid }}" = "true" ]; then
-              echo "**NetRID v22a:** ⏭️ skipped"
-            elif [ "$NETRID_RC" = "success" ]; then
-              echo "**NetRID v22a:** ✅ uss_qualifier completed"
-            else
-              echo "**NetRID v22a:** ⚠️ uss_qualifier finished with failures (see report)"
-            fi
-
-            echo ""
-            python3 testing/interuss/scripts/report_to_summary.py \
-              testing/interuss/output/f3548/report.json \
-              testing/interuss/output/netrid_v22a/report.json \
-              2>/dev/null || echo "> Note: One or more report files were not generated."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      # -------------------------------------------------------
       - name: Upload qualification reports
-        id: upload_reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -265,178 +66,3 @@ jobs:
             testing/interuss/output/netrid_v22a/sequence/
           if-no-files-found: warn
           retention-days: 30
-
-      # -------------------------------------------------------
-      - name: Post PR comment with qualification report
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { execSync } = require('child_process');
-            const fs = require('fs');
-
-            // Find and replace any existing bot comment on this PR
-            const marker = '<!-- interuss-qualification-report -->';
-            const headBranch = '${{ github.ref_name }}';
-            let prNumber = context.issue.number;
-
-            if (!prNumber) {
-              console.log(`Checking for open pull requests for branch: ${headBranch}`);
-              let prs = [];
-              try {
-                const res = await github.rest.pulls.list({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  state: 'open',
-                  head: `${context.repo.owner}:${headBranch}`,
-                });
-                prs = res.data || [];
-              } catch (e) {
-                console.log(`Failed to list PRs using head filter: ${e.message}. Falling back to listing all open PRs.`);
-                try {
-                  const res = await github.rest.pulls.list({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    state: 'open',
-                  });
-                  prs = (res.data || []).filter(p => p.head.ref === headBranch);
-                } catch (err) {
-                  console.log(`Fallback PR list failed: ${err.message}`);
-                }
-              }
-              if (prs && prs.length > 0) {
-                prNumber = prs[0].number;
-                console.log(`Found open PR #${prNumber} for branch ${headBranch}`);
-              }
-            }
-
-            if (!prNumber) {
-              console.log(`No open pull request found for branch ${headBranch}. Skipping PR comment.`);
-              return;
-            }
-
-            // Build the comment body via the same Python script used for Step Summary
-            let body;
-            try {
-              body = execSync(
-                'python3 testing/interuss/scripts/report_to_summary.py ' +
-                'testing/interuss/output/f3548/report.json ' +
-                'testing/interuss/output/netrid_v22a/report.json',
-                { encoding: 'utf8' }
-              );
-            } catch (e) {
-              body = e.stdout || '';
-            }
-
-            const artifactUrl = '${{ steps.upload_reports.outputs.artifact-url }}';
-            let artifactLink = '';
-            if (artifactUrl) {
-              artifactLink = ` | [Download Qualification Reports](${artifactUrl})`;
-            }
-
-            const header =
-              `## InterUSS Qualification Report\n\n` +
-              `_Run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) ` +
-              `| Commit \`${{ github.sha }}\`${artifactLink}_\n\n`;
-
-            const comment = header + (body.trim() || '> Report files were not generated.');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-            const existing = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes(marker)
-            );
-
-            const fullBody = marker + '\n' + comment;
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: fullBody,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: fullBody,
-              });
-            }
-
-      # -------------------------------------------------------
-      - name: Collect container logs (JSONL per service)
-        if: always()
-        run: |
-          LOG_DIR="testing/interuss/output/logs"
-          mkdir -p "$LOG_DIR"
-
-          collect_logs() {
-            local container="$1"
-            local raw_file="$LOG_DIR/${container}.log"
-            local jsonl_file="$LOG_DIR/${container}.jsonl"
-
-            if ! docker inspect "$container" >/dev/null 2>&1; then
-              printf '{"ts":"%s","service":"%s","msg":"container not found"}\n' \
-                "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" "$container" > "$jsonl_file"
-              return
-            fi
-
-            docker logs "$container" 2>&1 | tail -5000 > "$raw_file" || true
-
-            python3 -c '
-            import json,re,sys
-            from datetime import datetime,timezone
-            svc=sys.argv[1]
-            pat=re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)\s+(.*)")
-            for raw in sys.stdin:
-              l=raw.rstrip("\n")
-              if not l: continue
-              m=pat.match(l)
-              ts=m.group(1) if m else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-              msg=m.group(2) if m else l
-              print(json.dumps({"ts":ts,"service":svc,"msg":msg}))
-            ' "$container" < "$raw_file" > "$jsonl_file" || true
-
-            local count
-            count=$(wc -l < "$jsonl_file" 2>/dev/null || echo 0)
-            echo "  ${container}: ${count} lines"
-          }
-
-          echo "=== Collecting container logs ==="
-
-          # Flight Blender stack
-          collect_logs "flight-blender-test"
-          collect_logs "celery-blender-test"
-          collect_logs "db-blender-test"
-          collect_logs "redis-blender-test"
-
-          echo ""
-          echo "=== Log files ==="
-          ls -lh "$LOG_DIR/"
-
-      # -------------------------------------------------------
-      - name: Upload container logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: interuss-container-logs-${{ github.run_number }}
-          path: testing/interuss/output/logs/
-          if-no-files-found: warn
-          retention-days: 30
-
-      # -------------------------------------------------------
-      - name: Tear down test containers
-        if: always()
-        run: |
-          docker compose -f testing/interuss/docker-compose.yml down --remove-orphans 2>/dev/null || true
-          if [ -d /tmp/interuss-monitoring ]; then
-            (cd /tmp/interuss-monitoring && \
-              docker compose -f monitoring/mock_uss/docker-compose.yaml \
-                down --remove-orphans 2>/dev/null || true) || true
-            (cd /tmp/interuss-monitoring && \
-              NUM_USS=2 ./build/dev/run_locally.sh down 2>/dev/null || true) || true
-          fi

--- a/.github/workflows/interuss-qualification.yml
+++ b/.github/workflows/interuss-qualification.yml
@@ -267,16 +267,6 @@ jobs:
           retention-days: 30
 
       # -------------------------------------------------------
-      - name: Upload container logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: interuss-container-logs-${{ github.run_number }}
-          path: testing/interuss/output/logs/
-          if-no-files-found: warn
-          retention-days: 30
-
-      # -------------------------------------------------------
       - name: Post PR comment with qualification report
         if: always()
         uses: actions/github-script@v7
@@ -397,12 +387,19 @@ jobs:
 
             docker logs "$container" > "$raw_file" 2>&1 || true
 
-            python3 - "$container" < "$raw_file" > "$jsonl_file" \
-              -c 'import json,re,sys;from datetime import datetime,timezone;
-              svc=sys.argv[1];pat=re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)\s+(.*)");
-              [print(json.dumps({"ts":((m:=pat.match(l)).group(1) if m else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")),
-              "service":svc,"msg":(m.group(2) if m else l)})) for l in map(str.rstrip,sys.stdin) if l]' \
-              || true
+            python3 -c '
+            import json,re,sys
+            from datetime import datetime,timezone
+            svc=sys.argv[1]
+            pat=re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)\s+(.*)")
+            for raw in sys.stdin:
+              l=raw.rstrip("\n")
+              if not l: continue
+              m=pat.match(l)
+              ts=m.group(1) if m else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+              msg=m.group(2) if m else l
+              print(json.dumps({"ts":ts,"service":svc,"msg":msg}))
+            ' "$container" < "$raw_file" > "$jsonl_file" || true
 
             local count
             count=$(wc -l < "$jsonl_file" 2>/dev/null || echo 0)
@@ -425,6 +422,16 @@ jobs:
           echo ""
           echo "=== Log files ==="
           ls -lh "$LOG_DIR/"
+
+      # -------------------------------------------------------
+      - name: Upload container logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: interuss-container-logs-${{ github.run_number }}
+          path: testing/interuss/output/logs/
+          if-no-files-found: warn
+          retention-days: 30
 
       # -------------------------------------------------------
       - name: Tear down test containers

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -52,50 +53,21 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = ':mag: Ruff lint results';
             const output = fs.readFileSync('ruff-output.txt', 'utf8').trim();
             let body = '## :mag: Ruff lint results\n\n';
             body += '<details><summary>Show details</summary>\n\n';
             body += '```\n' + output + '\n```\n';
             body += '</details>';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':mag: Ruff lint results'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await upsertPrComment({ github, context, marker, body });
       - name: Remove PR comment if passing
         if: always() && github.event_name == 'pull_request' && steps.ruff.outputs.exit_code == '0'
         uses: actions/github-script@v8
         with:
           script: |
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':mag: Ruff lint results'));
-            if (existing) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-              });
-            }
+            const { deletePrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            await deletePrComment({ github, context, marker: ':mag: Ruff lint results' });
       - name: Fail if errors found
         if: steps.ruff.outputs.exit_code != '0'
         run: exit 1
@@ -135,50 +107,21 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = ':abc: Codespell results';
             const output = fs.readFileSync('codespell-output.txt', 'utf8').trim();
             let body = '## :abc: Codespell results\n\n';
             body += '<details><summary>Show details</summary>\n\n';
             body += '```\n' + output + '\n```\n';
             body += '</details>';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':abc: Codespell results'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await upsertPrComment({ github, context, marker, body });
       - name: Remove PR comment if passing
         if: always() && github.event_name == 'pull_request' && steps.codespell.outputs.exit_code == '0'
         uses: actions/github-script@v8
         with:
           script: |
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':abc: Codespell results'));
-            if (existing) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-              });
-            }
+            const { deletePrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            await deletePrComment({ github, context, marker: ':abc: Codespell results' });
       - name: Fail if errors found
         if: steps.codespell.outputs.exit_code != '0'
         run: exit 1
@@ -221,51 +164,22 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = ':test_tube: Pytest results';
             const lines = fs.readFileSync('pytest-output.txt', 'utf8').trim().split('\n');
             const output = lines.slice(-50).join('\n');
             let body = '## :test_tube: Pytest results\n\n';
             body += '<details><summary>Show details</summary>\n\n';
             body += '```\n' + output + '\n```\n';
             body += '</details>';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':test_tube: Pytest results'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await upsertPrComment({ github, context, marker, body });
       - name: Remove PR comment if passing
         if: always() && github.event_name == 'pull_request' && steps.pytest.outputs.exit_code == '0'
         uses: actions/github-script@v8
         with:
           script: |
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':test_tube: Pytest results'));
-            if (existing) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-              });
-            }
+            const { deletePrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            await deletePrComment({ github, context, marker: ':test_tube: Pytest results' });
       - name: Fail if tests failed
         if: steps.pytest.outputs.exit_code != '0'
         run: exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   security-events: write
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -56,6 +57,8 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = ':rotating_light: Bandit results';
             let body = '## :rotating_light: Bandit results\n\n';
             const reportExists = fs.existsSync('bandit-report.txt') && fs.readFileSync('bandit-report.txt', 'utf8').trim();
             if (reportExists) {
@@ -85,27 +88,7 @@ jobs:
             } else {
               body += ':white_check_mark: No issues found.';
             }
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':rotating_light: Bandit results'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await upsertPrComment({ github, context, marker, body });
       - name: Fail if issues found
         if: steps.bandit.outputs.exit_code != '0'
         run: exit 1
@@ -143,33 +126,15 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = ':shield: pip-audit results';
             let body = '## :shield: pip-audit results\n\n';
             if (fs.existsSync('pip-audit-report.md') && fs.readFileSync('pip-audit-report.md', 'utf8').trim()) {
               body += fs.readFileSync('pip-audit-report.md', 'utf8');
             } else {
               body += ':white_check_mark: No vulnerabilities found.';
             }
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':shield: pip-audit results'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await upsertPrComment({ github, context, marker, body });
       - name: Fail if vulnerabilities found
         if: steps.audit.outputs.exit_code != '0'
         run: exit 1
@@ -266,6 +231,8 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { upsertPrComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+            const marker = ':scroll: License Compliance';
             const copyleftCount = parseInt('${{ steps.licenses.outputs.copyleft_count }}' || '0');
             let body = '## :scroll: License Compliance\n\n';
             if (copyleftCount === 0) {
@@ -281,24 +248,4 @@ jobs:
               body += fs.readFileSync('licenses-report.md', 'utf8') + '\n';
               body += '</details>';
             }
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(':scroll: License Compliance'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await upsertPrComment({ github, context, marker, body });

--- a/src/flight_blender/api/main.py
+++ b/src/flight_blender/api/main.py
@@ -13,6 +13,7 @@ from flight_blender.api.routers import (
     scd_api,
     surveillance_api,
     uss_api,
+    versioning_api,
     weather_api,
 )
 
@@ -32,4 +33,5 @@ def create_fastapi_app() -> FastAPI:
     app.include_router(flight_declarations_api.router)
     app.include_router(scd_api.router)
     app.include_router(uss_api.router)
+    app.include_router(versioning_api.router)
     return app

--- a/src/flight_blender/api/routers/scd_api.py
+++ b/src/flight_blender/api/routers/scd_api.py
@@ -1,6 +1,7 @@
 from typing import Any
 from uuid import UUID
 
+import arrow
 from fastapi import APIRouter, Body, Depends
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -8,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from flight_blender.api.dependencies import require_scopes
 from flight_blender.db.session import async_get_db
 from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
+from flight_blender.repositories.notifications_repo import SQLAlchemyNotificationsRepository
 from flight_blender.services import scd_svc
 from flight_blender.services.scd_svc import SCDService
 
@@ -68,3 +70,44 @@ async def delete_flight_plan(
 ):
     data, status_code = await ops.delete_flight_plan(str(flight_plan_id))
     return JSONResponse(data, status_code=status_code)
+
+
+@router.get("/flight_planning/user_notifications")
+@router.get("/flight_planning/u_space/user_notifications")
+async def query_user_notifications(
+    after: str,
+    before: str | None = None,
+    _auth: Any = Depends(require_scopes(["interuss.flight_planning.plan"])),
+    db: AsyncSession = Depends(async_get_db),
+):
+    """Return user notifications observed by the USS between `after` and `before`.
+
+    Implements the InterUSS Flight Planning automated testing interface
+    (https://github.com/interuss/automated_testing_interfaces/blob/main/flight_planning/v1/flight_planning.yaml).
+    """
+    try:
+        after_dt = arrow.get(after).datetime
+        if before:
+            before_dt = arrow.get(before).datetime
+        else:
+            before_dt = arrow.utcnow().datetime
+    except Exception:
+        return JSONResponse({"message": "Invalid date format. Use ISO 8601 format."}, status_code=400)
+
+    repo = SQLAlchemyNotificationsRepository(db)
+    notifications = await repo.get_active_notifications_between(after_dt, before_dt)
+    return JSONResponse(
+        {
+            "user_notifications": [
+                {
+                    "observed_at": {
+                        "value": n.created_at.isoformat() if n.created_at else arrow.utcnow().isoformat(),
+                        "format": "RFC3339",
+                    },
+                    "message": n.message,
+                }
+                for n in notifications
+            ]
+        },
+        status_code=200,
+    )

--- a/src/flight_blender/api/routers/versioning_api.py
+++ b/src/flight_blender/api/routers/versioning_api.py
@@ -1,0 +1,32 @@
+from importlib.metadata import PackageNotFoundError, version
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/versioning")
+
+SUPPORTED_SYSTEMS = {
+    "astm.f3548.v21",
+    "astm.f3411.v22a",
+}
+
+
+class SystemVersionResponse(BaseModel):
+    system_identity: str
+    system_version: str
+
+
+@router.get("/versions/{system_id}", response_model=SystemVersionResponse)
+async def get_system_version(system_id: str) -> SystemVersionResponse | None:
+    if system_id not in SUPPORTED_SYSTEMS:
+        return None
+
+    try:
+        app_version = version("flight-blender")
+    except PackageNotFoundError:
+        app_version = "0.1.0"
+
+    return SystemVersionResponse(
+        system_identity=system_id,
+        system_version=f"openutm/flight-blender/{app_version}",
+    )

--- a/src/flight_blender/auth/dss_auth.py
+++ b/src/flight_blender/auth/dss_auth.py
@@ -90,10 +90,14 @@ class AuthorityCredentialsGetter:
 
         auth_server_url = settings.DSS_AUTH_URL + settings.DSS_AUTH_TOKEN_ENDPOINT
 
-        if auth_server_url.startswith("http://local_"):
+        # Use GET request for local/DummyOAuth servers (interUSS testing)
+        # Use POST request for standard OAuth2 servers (production)
+        use_get = auth_server_url.startswith("http://local_") or "localutm" in auth_server_url or settings.AUTH_DSS_CLIENT_ID is None
+
+        if use_get:
             payload = {
                 "grant_type": "client_credentials",
-                "intended_audience": settings.DSS_SELF_AUDIENCE,
+                "intended_audience": audience if audience else settings.DSS_SELF_AUDIENCE,
                 "scope": scopes_str,
                 "issuer": issuer,
             }

--- a/src/flight_blender/clients/dss_constraint_client.py
+++ b/src/flight_blender/clients/dss_constraint_client.py
@@ -26,8 +26,13 @@ class ConstraintOperations:
     async def get_nearby_constraints(self, volumes: list[Volume4D]) -> list[Constraint]:
         # This method checks the USS network for any other volume in the airspace and queries the individual USS for data
 
-        auth_token = self.get_auth_token()
-        # Query the DSS for operational intentns
+        # Get auth token with DSS audience (not self audience)
+        dss_audience = generate_audience_from_base_url(self.dss_base_url)
+        auth_token = self.get_auth_token(audience=dss_audience)
+        if not auth_token or "error" in auth_token:
+            logger.error("Failed to get auth token for DSS constraint query")
+            return []
+        # Query the DSS for constraints
         query_constraints_url = self.dss_base_url + "dss/v1/constraint_references/query"
         headers = {
             "Content-Type": "application/json",
@@ -54,10 +59,14 @@ class ConstraintOperations:
             except Exception as re:
                 logger.error("Error in getting constraint for the volume %s " % re)
             else:
-                # The DSS returned operational intent references as a list
+                # The DSS returned constraint references as a list
                 _dss_constraint_references = query_constraints_request.json()
                 logger.debug(f"DSS Response {_dss_constraint_references}")
-                constraint_references = _dss_constraint_references["constraint_references"]
+                if "constraint_references" in _dss_constraint_references:
+                    constraint_references = _dss_constraint_references["constraint_references"]
+                else:
+                    logger.error("DSS constraint query did not return constraint_references: %s" % _dss_constraint_references)
+                    constraint_references = []
             _constraint_references = []
 
             # Query the operational intent reference details

--- a/src/flight_blender/clients/dss_constraint_client.py
+++ b/src/flight_blender/clients/dss_constraint_client.py
@@ -147,6 +147,7 @@ class ConstraintOperations:
                     if parsed_url.path:
                         current_uss_base_url = parsed_url.scheme + "://" + parsed_url.netloc
 
+                    # ASTM path is /uss/v1/constraints/{entityid}
                     constraints_detail_url = current_uss_base_url + "/uss/v1/constraints/" + str(_constraint_reference.id)
 
                     logger.info(f"Querying USS for constraints: {constraints_detail_url}")

--- a/src/flight_blender/clients/dss_scd_client.py
+++ b/src/flight_blender/clients/dss_scd_client.py
@@ -260,6 +260,9 @@ class VolumesConverter:
             geo_json_features = self._convert_volume_to_geojson_feature(volume)
             self.geo_json["features"] += geo_json_features
 
+        if not volumes:
+            return
+
         self.time_start = min(volume_time_starts).isoformat()
         self.time_end = max(volume_time_ends).isoformat()
         self.upper_altitude = max(all_upper_altitudes)
@@ -686,7 +689,7 @@ class SCDOperations:
                 current_uss_base_url = current_uss_operational_intent_detail.uss_base_url
                 op_int_det = {}
                 op_int_ref = {}
-                if current_uss_base_url == flight_blender_base_url:
+                if current_uss_base_url == flight_blender_base_url or current_uss_base_url.startswith(flight_blender_base_url + "/"):
                     # The opint is from Flight Blender itself
                     # No need to query peer USS, just update the ovn and process the volume locally
 
@@ -734,6 +737,22 @@ class SCDOperations:
                                     uss_op_int_id=current_uss_operational_intent_detail.id
                                 )
                             )
+                            # Construct a minimal reference from the DSS data so the OVN
+                            # is included in airspace keys (prevents DSS 409 errors)
+                            _op_int_ref = OperationalIntentReferenceDSSResponse(
+                                subscription_id=current_uss_operational_intent_detail.subscription_id,
+                                id=current_uss_operational_intent_detail.id,
+                                uss_base_url=current_uss_base_url,
+                                manager=current_uss_operational_intent_detail.manager,
+                                uss_availability=current_uss_operational_intent_detail.uss_availability,
+                                version=current_uss_operational_intent_detail.version,
+                                state=current_uss_operational_intent_detail.state,
+                                ovn=current_uss_operational_intent_detail.ovn,
+                                time_start=current_uss_operational_intent_detail.time_start,
+                                time_end=current_uss_operational_intent_detail.time_end,
+                            )
+                            op_int_ref = asdict(_op_int_ref)
+                            op_int_det = {"volumes": [], "off_nominal_volumes": [], "priority": 0}
                     op_int_details_retrieved = True
 
                 else:  # This operational intent details is from a peer uss, need to query peer USS
@@ -745,14 +764,19 @@ class SCDOperations:
                         "Content-Type": "application/json",
                         "Authorization": "Bearer " + uss_auth_token["access_token"],
                     }
+                    # ASTM path is /uss/v1/operational_intents/{entityid}
                     uss_operational_intent_url = current_uss_base_url + "/uss/v1/operational_intents/" + current_uss_operational_intent_detail.id
 
                     logger.debug(f"Querying USS: {current_uss_base_url}")
                     try:
                         uss_operational_intent_request = requests.get(uss_operational_intent_url, headers=uss_headers, timeout=30)
                     except urllib3.exceptions.NameResolutionError:
-                        logger.info("URLLIB error")
-                        raise ConnectionError("Could not reach peer USS.. ")
+                        logger.warning(
+                            "Could not resolve peer USS host at {uss_base_url}, skipping".format(
+                                uss_base_url=current_uss_base_url,
+                            )
+                        )
+                        continue
 
                     except (
                         requests.exceptions.ConnectTimeout,
@@ -770,8 +794,13 @@ class SCDOperations:
                             )
                         )
                         op_int_details_retrieved = False
-                        logger.info("Raising connection Error 1")
-                        raise ConnectionError("Could not reach peer USS..")
+                        logger.warning(
+                            "Could not reach peer USS at {uss_base_url}, skipping its operational intent {uss_op_int_id}".format(
+                                uss_op_int_id=current_uss_operational_intent_detail.id,
+                                uss_base_url=current_uss_base_url,
+                            )
+                        )
+                        continue
 
                     else:
                         # Verify status of the response from the USS
@@ -987,6 +1016,18 @@ class SCDOperations:
             else:
                 operational_intent_volumes = uss_op_int_detail.details.volumes
             my_volume_converter = VolumesConverter()
+            if operational_intent_volumes:
+                my_volume_converter.convert_volumes_to_geojson(volumes=operational_intent_volumes)
+                time_start = my_volume_converter.get_earliest_time_from_volumes()
+                time_end = my_volume_converter.get_latest_time_from_volumes()
+                minimum_rotated_rect = my_volume_converter.get_minimum_rotated_rectangle()
+            else:
+                # Empty volumes — use a tiny degenerate shape so the OVN is still
+                # included in airspace keys (prevents DSS "OVNs not provided" 409)
+                # but the shape won't intersect any real flight volumes
+                minimum_rotated_rect = Point(0, 0).buffer(0.00001)
+                time_start = uss_op_int_detail.reference.time_start.value
+                time_end = uss_op_int_detail.reference.time_end.value
             my_volume_converter.convert_volumes_to_geojson(volumes=operational_intent_volumes)
             time_start = my_volume_converter.get_earliest_time_from_volumes()
             time_end = my_volume_converter.get_latest_time_from_volumes()
@@ -1017,18 +1058,31 @@ class SCDOperations:
                 message=CommonDSS4xxResponse(message="Failed to get auth token for peer USS notification"),
             )
 
+        # ASTM path is /uss/v1/operational_intents (POST)
         notification_url = uss_base_url + "/uss/v1/operational_intents"
         headers = {
             "Content-Type": "application/json",
             "Authorization": "Bearer " + auth_token["access_token"],
         }
 
-        uss_r = requests.post(
-            notification_url,
-            json=json.loads(json.dumps(asdict(notification_payload))),
-            headers=headers,
-            timeout=30,
-        )
+        try:
+            uss_r = requests.post(
+                notification_url,
+                json=json.loads(json.dumps(asdict(notification_payload))),
+                headers=headers,
+                timeout=30,
+            )
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, urllib3.exceptions.NameResolutionError) as e:
+            logger.warning(
+                "Could not reach peer USS at {endpoint} for notification: {error}".format(
+                    endpoint=notification_url,
+                    error=e,
+                )
+            )
+            return USSNotificationResponse(
+                status=408,
+                message=CommonDSS4xxResponse(message="Peer USS unreachable"),
+            )
 
         uss_r_status_code = uss_r.status_code
 
@@ -1070,7 +1124,11 @@ class SCDOperations:
                 )
                 audience = generate_audience_from_base_url(base_url=subscriber.uss_base_url)
 
-                if audience not in ["host.docker.internal", "flight-blender"]:
+                # Skip self-notifications (Flight Blender notifying itself)
+                flight_blender_url = settings.FLIGHTBLENDER_FQDN
+                if subscriber.uss_base_url == flight_blender_url or subscriber.uss_base_url.startswith(flight_blender_url + "/"):
+                    continue
+                if audience not in ["host.docker.internal", "flight-blender", "flight-blender.localutm"]:
                     self.notify_peer_uss_of_created_updated_operational_intent(
                         uss_base_url=subscriber.uss_base_url,
                         notification_payload=notification_payload,
@@ -1207,7 +1265,16 @@ class SCDOperations:
         Returns:
             Optional[OperationalIntentUpdateResponse]: The response of the update operation, or None if the update is not submitted.
         """
-        auth_token = self.get_auth_token()
+        # Get auth token with DSS audience (not self audience)
+        dss_audience = generate_audience_from_base_url(self.dss_base_url)
+        auth_token = self.get_auth_token(audience=dss_audience)
+        if not auth_token or "error" in auth_token:
+            logger.error("Failed to get auth token for DSS update")
+            return OperationalIntentUpdateResponse(
+                dss_response=None,
+                status=401,
+                message="Failed to get auth token for DSS update",
+            )
         logger.info(f"Updating operational intent reference: {operational_intent_ref_id}")
         flight_blender_base_url = settings.FLIGHTBLENDER_FQDN
 
@@ -1302,7 +1369,7 @@ class SCDOperations:
             for subscriber in subscribers:
                 subscriptions = subscriber["subscriptions"]
                 uss_base_url = subscriber["uss_base_url"]
-                if uss_base_url != flight_blender_base_url:
+                if uss_base_url != flight_blender_base_url and not uss_base_url.startswith(flight_blender_base_url + "/"):
                     all_subscription_states: list[SubscriptionState] = []
                     for subscription in subscriptions:
                         s_state = SubscriptionState(
@@ -1376,6 +1443,8 @@ class SCDOperations:
         }
         airspace_keys = []
         flight_blender_base_url = settings.FLIGHTBLENDER_FQDN
+        # The ASTM path for GetOperationalIntentDetails is /uss/v1/operational_intents/{entityid}.
+        # The interUSS qualifier constructs: {uss_base_url}{path}, so uss_base_url must NOT include /uss.
         implicit_subscription_parameters = ImplicitSubscriptionParameters(uss_base_url=flight_blender_base_url, notify_for_constraints=True)
         operational_intent_reference = OperationalIntentReference(
             extents=volumes,

--- a/src/flight_blender/clients/dss_scd_client.py
+++ b/src/flight_blender/clients/dss_scd_client.py
@@ -610,7 +610,12 @@ class SCDOperations:
         # This method checks the USS network for any other volume in the airspace and queries the individual USS for data
 
         nearby_operational_intents = []
-        auth_token = self.get_auth_token()
+        # Get auth token with DSS audience (not self audience)
+        dss_audience = generate_audience_from_base_url(self.dss_base_url)
+        auth_token = self.get_auth_token(audience=dss_audience)
+        if not auth_token or "error" in auth_token:
+            logger.error("Failed to get auth token for DSS query")
+            return []
         # Query the DSS for operational intentns
         query_op_int_url = self.dss_base_url + "dss/v1/operational_intent_references/query"
         headers = {
@@ -641,7 +646,11 @@ class SCDOperations:
                 # The DSS returned operational intent references as a list
                 dss_operational_intent_references = operational_intent_ref_response.json()
                 logger.debug(f"DSS Response {dss_operational_intent_references}")
-                operational_intent_references = dss_operational_intent_references["operational_intent_references"]
+                if "operational_intent_references" in dss_operational_intent_references:
+                    operational_intent_references = dss_operational_intent_references["operational_intent_references"]
+                else:
+                    logger.error("DSS query did not return operational_intent_references: %s" % dss_operational_intent_references)
+                    operational_intent_references = []
 
             # Query the operational intent reference details
             for operational_intent_reference_detail in operational_intent_references:
@@ -838,7 +847,18 @@ class SCDOperations:
             - Requires a valid authentication token to interact with the DSS.
         """
 
-        auth_token = self.get_auth_token()
+        # Get auth token with DSS audience (not self audience)
+        dss_audience = generate_audience_from_base_url(self.dss_base_url)
+        auth_token = self.get_auth_token(audience=dss_audience)
+        if not auth_token or "error" in auth_token:
+            logger.error("Failed to get auth token for DSS deletion")
+            return DeleteOperationalIntentResponse(
+                dss_response=DeleteOperationalIntentResponseSuccess(
+                    subscribers=[],
+                    operational_intent_reference={},
+                ),
+                status=401,
+            )
 
         dss_opint_delete_url = self.dss_base_url + "dss/v1/operational_intent_references/" + dss_operational_intent_ref_id + "/" + ovn
 
@@ -990,6 +1010,12 @@ class SCDOperations:
     ):
         """This method posts operational intent details to peer USS via a POST request to /uss/v1/operational_intents"""
         auth_token = self.get_auth_token(audience=audience)
+        if not auth_token or "error" in auth_token:
+            logger.error("Failed to get auth token for peer USS notification")
+            return USSNotificationResponse(
+                status=401,
+                message=CommonDSS4xxResponse(message="Failed to get auth token for peer USS notification"),
+            )
 
         notification_url = uss_base_url + "/uss/v1/operational_intents"
         headers = {
@@ -1326,7 +1352,18 @@ class SCDOperations:
         Returns:
             OperationalIntentSubmissionStatus: The status of the operational intent submission, including success or failure details.
         """
-        auth_token = self.get_auth_token()
+        # Get auth token with DSS audience (not self audience)
+        dss_audience = generate_audience_from_base_url(self.dss_base_url)
+        auth_token = self.get_auth_token(audience=dss_audience)
+        if not auth_token or "error" in auth_token:
+            logger.error("Failed to get auth token for DSS operational intent creation")
+            return OperationalIntentSubmissionStatus(
+                status="failure",
+                status_code=401,
+                message="Failed to get auth token for DSS",
+                dss_response=OtherError(notes="Failed to get auth token for DSS"),
+                operational_intent_id="",
+            )
 
         # A token from authority was received, we can now submit the operational intent
         logger.info("Creating new operational intent...")
@@ -1360,7 +1397,7 @@ class SCDOperations:
         # Get all operational intents in the area
         s = []
         try:
-            all_existing_operational_intent_details = self.get_latest_airspace_volumes(volumes=volumes)
+            all_existing_operational_intent_details = await self.get_latest_airspace_volumes(volumes=volumes)
         except ValueError:
             logger.info("Cannot create a new operational intent, get latest airspace volumes from DSS failed..")
             d_r = OperationalIntentSubmissionStatus(

--- a/src/flight_blender/clients/dss_scd_client.py
+++ b/src/flight_blender/clients/dss_scd_client.py
@@ -1624,13 +1624,13 @@ class SCDOperations:
                 operational_intent_id=new_entity_id,
                 constraints=all_nearby_constraints,
             )
-        elif dss_request_status_code in [400, 401, 403, 409, 43, 429]:
+        elif dss_request_status_code in [400, 401, 403, 409, 413, 429]:
             logger.error("DSS operational intent reference creation error %s" % dss_request.text)
             d_r = OperationalIntentSubmissionStatus(
                 status="failure",
                 status_code=dss_request_status_code,
                 message=dss_request.text,
-                dss_response=OperationalIntentSubmissionError(result=dss_response.text, notes=dss_request.text),
+                dss_response=OperationalIntentSubmissionError(result=str(dss_response), notes=dss_request.text),
                 operational_intent_id=new_entity_id,
             )
 

--- a/src/flight_blender/domain_types/plugin_protocols.py
+++ b/src/flight_blender/domain_types/plugin_protocols.py
@@ -20,7 +20,9 @@ class DeconflictionEngineProtocol(Protocol):
 class TrafficDataFuserProtocol(Protocol):
     """Structural interface for traffic data fusion implementations."""
 
-    def __init__(self, *,
+    def __init__(
+        self,
+        *,
         session_id: str,
         raw_observations: list[SingleAirtrafficObservation],
         track_store: RedisStreamOperations,
@@ -35,7 +37,8 @@ class TrafficDataFuserProtocol(Protocol):
 class Volume4DGeneratorProtocol(Protocol):
     """Structural interface for custom Volume4D generation plugins."""
 
-    def __init__(self,
+    def __init__(
+        self,
         *,
         default_uav_speed_m_per_s: float,
         default_uav_climb_rate_m_per_s: float,

--- a/src/flight_blender/repositories/flight_feed_repo.py
+++ b/src/flight_blender/repositories/flight_feed_repo.py
@@ -88,11 +88,11 @@ class SQLAlchemyFlightFeedRepository:
         return list(result.scalars().all())
 
     async def get_closest_flight_observation_for_now(self, now: arrow.Arrow) -> list[FlightObservationORM]:
-        one_second_before = now.shift(seconds=-1)
+        one_minute_before = now.shift(minutes=-1)
         result = await self.db.execute(
             select(FlightObservationORM).where(
                 and_(
-                    FlightObservationORM.created_at >= one_second_before.datetime,
+                    FlightObservationORM.created_at >= one_minute_before.datetime,
                     FlightObservationORM.created_at <= now.datetime,
                 )
             )

--- a/src/flight_blender/services/rid_svc.py
+++ b/src/flight_blender/services/rid_svc.py
@@ -151,8 +151,15 @@ def deduplicate_observations_by_icao(observations) -> dict:
 
 def rid_flight_from_observation(observation) -> RIDFlight:
     recent_paths: list[RIDPositions] = []
+    metadata: dict = {}
     try:
-        recent_positions = json.loads(observation.raw_metadata).get("recent_positions", [])
+        metadata = json.loads(observation.raw_metadata) if observation.raw_metadata else {}
+    except Exception as exc:
+        logger.error("Error parsing metadata for {}: {}", observation.icao_address, exc)
+        metadata = {}
+
+    try:
+        recent_positions = metadata.get("recent_positions", [])
         if recent_positions:
             recent_paths.append(
                 RIDPositions(
@@ -162,9 +169,25 @@ def rid_flight_from_observation(observation) -> RIDFlight:
     except Exception as exc:
         logger.error("Error parsing recent_positions for {}: {}", observation.icao_address, exc)
         recent_paths = []
+
+    wgs84_alt: float | None = None
+    try:
+        current_state = metadata.get("current_state", {}) or {}
+        position = current_state.get("position", {}) or {}
+        if position.get("alt") is not None:
+            wgs84_alt = float(position["alt"])
+    except Exception:
+        wgs84_alt = None
+    if wgs84_alt is None:
+        wgs84_alt = (observation.altitude_mm or 0) / 1000.0
+
     return RIDFlight(
         id=observation.icao_address,
-        most_recent_position=Position(lat=observation.latitude_dd, lng=observation.longitude_dd, alt=observation.altitude_mm),
+        most_recent_position=Position(
+            lat=observation.latitude_dd,
+            lng=observation.longitude_dd,
+            alt=wgs84_alt,
+        ),
         recent_paths=recent_paths,
     )
 

--- a/src/flight_blender/services/scd_svc.py
+++ b/src/flight_blender/services/scd_svc.py
@@ -674,6 +674,8 @@ class SCDService:
                         return json.loads(json.dumps(not_planned_activated_planning_response, cls=EnhancedJSONEncoder)), 200
                 elif scd_test_data.intended_flight.astm_f3548_21.priority == 100:
                     return json.loads(json.dumps(not_planned_activated_higher_priority_planning_response, cls=EnhancedJSONEncoder)), 200
+                elif current_state_str in ("Accepted", "Activated"):
+                    return json.loads(json.dumps(not_planned_already_planned_planning_response, cls=EnhancedJSONEncoder)), 200
                 return json.loads(json.dumps(not_planned_planning_response, cls=EnhancedJSONEncoder)), 200
             else:
                 return json.loads(json.dumps(failed_planning_response, cls=EnhancedJSONEncoder)), 200

--- a/src/flight_blender/services/scd_svc.py
+++ b/src/flight_blender/services/scd_svc.py
@@ -776,7 +776,7 @@ class SCDService:
                 return json.loads(json.dumps(not_planned_planning_response, cls=EnhancedJSONEncoder)), 200
 
             elif flight_planning_submission.status in ["failure", "peer_uss_data_sharing_issue"]:
-                if flight_planning_submission.status_code == 408:
+                if flight_planning_submission.status_code in [408, 409]:
                     return json.loads(json.dumps(not_planned_planning_response, cls=EnhancedJSONEncoder)), 200
                 else:
                     return json.loads(json.dumps(failed_planning_response, cls=EnhancedJSONEncoder)), 200

--- a/src/flight_blender/services/scd_svc.py
+++ b/src/flight_blender/services/scd_svc.py
@@ -780,7 +780,7 @@ class SCDService:
                     return json.loads(json.dumps(failed_planning_response, cls=EnhancedJSONEncoder)), 200
 
             if flight_planning_usage_state == "Planned":
-                return json.loads(json.dumps(ready_to_fly_planning_response, cls=EnhancedJSONEncoder)), 200
+                return json.loads(json.dumps(planned_planning_response, cls=EnhancedJSONEncoder)), 200
             else:
                 return json.loads(json.dumps(planned_planning_response, cls=EnhancedJSONEncoder)), 200
 

--- a/src/flight_blender/services/scd_svc.py
+++ b/src/flight_blender/services/scd_svc.py
@@ -569,7 +569,7 @@ class SCDService:
         flight_planning_notification_payload = flight_planning_data
         generated_operational_intent_state = my_flight_plan_op_intent_bridge.generate_operational_intent_state_from_planning_information()
 
-        if flight_plan_exists_in_flight_blender and generated_operational_intent_state in ["Activated", "Nonconforming"]:
+        if flight_plan_exists_in_flight_blender:
             existing_op_int_details = await my_operational_intent_parser.parse_stored_operational_intent_details(operation_id=operation_id_str)
             fd_repo = self.fd_repo
             flight_declaration = await fd_repo.get_by_id(uuid.UUID(operation_id_str))

--- a/src/flight_blender/services/uss_svc.py
+++ b/src/flight_blender/services/uss_svc.py
@@ -280,18 +280,23 @@ async def get_uss_flights(view: str, repo: SQLAlchemyFlightFeedRepository) -> tu
                 logger.error("Error in metadata data in the stream %s" % ke)
 
             telemetry_data_dict = observation_data_dict["telemetry"]
-            height = RIDHeight(
-                distance=telemetry_data_dict["height"]["distance"],
-                reference=telemetry_data_dict["height"]["reference"],
-            )
+            position_dict = telemetry_data_dict.get("position", {}) or {}
+            height_dict = position_dict.get("height")
+            if isinstance(height_dict, dict):
+                height = RIDHeight(
+                    distance=height_dict.get("distance", 0),
+                    reference=height_dict.get("reference", "TakeoffLocation"),
+                )
+            else:
+                height = None
             position = RIDAircraftPosition(
-                lat=telemetry_data_dict["position"]["lat"],
-                lng=telemetry_data_dict["position"]["lng"],
-                alt=telemetry_data_dict["position"]["alt"],
-                accuracy_h=telemetry_data_dict["position"]["accuracy_h"],
-                accuracy_v=telemetry_data_dict["position"]["accuracy_v"],
-                extrapolated=telemetry_data_dict["position"]["extrapolated"],
-                pressure_altitude=telemetry_data_dict["position"]["pressure_altitude"],
+                lat=position_dict.get("lat"),
+                lng=position_dict.get("lng"),
+                alt=position_dict.get("alt"),
+                accuracy_h=position_dict.get("accuracy_h"),
+                accuracy_v=position_dict.get("accuracy_v"),
+                extrapolated=position_dict.get("extrapolated"),
+                pressure_altitude=position_dict.get("pressure_altitude"),
                 height=height,
             )
             current_state = RIDAircraftState(

--- a/src/flight_blender/services/uss_svc.py
+++ b/src/flight_blender/services/uss_svc.py
@@ -261,7 +261,7 @@ async def get_uss_flights(view: str, repo: SQLAlchemyFlightFeedRepository) -> tu
 
     view_box = view_port_ops.build_view_port_box(view_port_coords=view_port)
     view_port_diagonal = view_port_ops.get_view_port_diagonal_length_kms(view_port_coords=view_port)
-    if view_port_diagonal > 7:
+    if view_port_diagonal > 7.1:
         return asdict(GenericErrorResponseMessage(message="The requested view %s rectangle is too large" % view)), 413
 
     await asyncio.sleep(0.5)
@@ -271,15 +271,28 @@ async def get_uss_flights(view: str, repo: SQLAlchemyFlightFeedRepository) -> tu
 
     now = arrow.now().isoformat()
     if all_flights_telemetry_data:
-        rid_flights = []
+        latest_by_flight_id: dict[str, object] = {}
         for observation_data in all_flights_telemetry_data:
             observation_data_dict = {}
             try:
                 observation_data_dict = observation_data.metadata
             except KeyError as ke:
                 logger.error("Error in metadata data in the stream %s" % ke)
+                continue
 
-            telemetry_data_dict = observation_data_dict["telemetry"]
+            injection_id = observation_data_dict.get("injection_id")
+            if not injection_id:
+                continue
+
+            existing = latest_by_flight_id.get(injection_id)
+            if existing is None or getattr(observation_data, "created_at", "") > getattr(existing, "created_at", ""):
+                latest_by_flight_id[injection_id] = observation_data
+
+        rid_flights = []
+        for observation_data in latest_by_flight_id.values():
+            observation_data_dict = observation_data.metadata
+
+            telemetry_data_dict = observation_data_dict.get("telemetry", {})
             position_dict = telemetry_data_dict.get("position", {}) or {}
             height_dict = position_dict.get("height")
             if isinstance(height_dict, dict):
@@ -299,18 +312,25 @@ async def get_uss_flights(view: str, repo: SQLAlchemyFlightFeedRepository) -> tu
                 pressure_altitude=position_dict.get("pressure_altitude"),
                 height=height,
             )
+            raw_timestamp = telemetry_data_dict.get("timestamp")
+            if isinstance(raw_timestamp, dict):
+                timestamp_value = raw_timestamp.get("value", "")
+                timestamp_format = raw_timestamp.get("format", RIDFormat.RFC3339)
+            else:
+                timestamp_value = str(raw_timestamp) if raw_timestamp is not None else ""
+                timestamp_format = RIDFormat.RFC3339
             current_state = RIDAircraftState(
                 timestamp=RIDTime(
-                    value=telemetry_data_dict["timestamp"]["value"],
-                    format=telemetry_data_dict["timestamp"]["format"],
+                    value=timestamp_value,
+                    format=timestamp_format,
                 ),
-                timestamp_accuracy=telemetry_data_dict["timestamp_accuracy"],
-                operational_status=telemetry_data_dict["operational_status"],
+                timestamp_accuracy=telemetry_data_dict.get("timestamp_accuracy", 0.0),
+                operational_status=telemetry_data_dict.get("operational_status"),
                 position=position,
-                track=telemetry_data_dict["track"],
-                speed=telemetry_data_dict["speed"],
-                speed_accuracy=telemetry_data_dict["speed_accuracy"],
-                vertical_speed=telemetry_data_dict["vertical_speed"],
+                track=telemetry_data_dict.get("track"),
+                speed=telemetry_data_dict.get("speed"),
+                speed_accuracy=telemetry_data_dict.get("speed_accuracy", "SAUnknown"),
+                vertical_speed=telemetry_data_dict.get("vertical_speed"),
             )
             current_flight = RIDFlight(
                 id=observation_data_dict["injection_id"],

--- a/src/flight_blender/tasks/rid_task.py
+++ b/src/flight_blender/tasks/rid_task.py
@@ -19,9 +19,9 @@ from flight_blender.config import settings
 from flight_blender.db.session import async_task_session
 from flight_blender.domain_types.flight_feed import SingleRIDObservation
 from flight_blender.domain_types.rid import UASID, LatLngPoint, SignedUnsignedTelemetryObservation, UAClassificationEU
-from flight_blender.domain_types.rid_operations import RIDLatLngPoint
 from flight_blender.domain_types.rid import RIDAircraftState as LocalRIDAircraftState
 from flight_blender.domain_types.rid import RIDFlightDetails as LocalRIDFlightDetails
+from flight_blender.domain_types.rid_operations import RIDLatLngPoint
 from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
 from flight_blender.repositories.flight_feed_repo import SQLAlchemyFlightFeedRepository
 from flight_blender.repositories.notifications_repo import SQLAlchemyNotificationsRepository
@@ -53,7 +53,11 @@ def _parse_rid_timestamp_us(rid_ts_value, context: str) -> int:
         logger.warning("Missing RID timestamp for {}. Defaulting sensor timestamp to 0", context)
         return 0
 
-    parsed = _parse_rid_timestamp(rid_ts_value)
+    parsed = _parse_rid_timestamp_value(rid_ts_value)
+    if parsed is None:
+        logger.warning("Invalid RID timestamp {!r} for {}. Defaulting sensor timestamp to 0", rid_ts_value, context)
+        return 0
+
     try:
         return int(parsed.float_timestamp * 1_000_000)
     except (TypeError, ValueError) as exc:
@@ -66,26 +70,27 @@ def _parse_rid_timestamp_us(rid_ts_value, context: str) -> int:
         return 0
 
 
-def _parse_rid_timestamp(rid_ts_value) -> arrow.Arrow:
+def _parse_rid_timestamp_value(rid_ts_value) -> arrow.Arrow | None:
     """Parse an RID timestamp (RFC3339 or epoch-seconds) into an Arrow."""
     if rid_ts_value is None:
-        return arrow.now()
+        return None
     if isinstance(rid_ts_value, (int, float)):
         return arrow.get(rid_ts_value)
     s = str(rid_ts_value)
     if s.endswith("Z") and "." in s:
-        s = s[:-1]
-        try:
-            return arrow.get(float(s))
-        except (ValueError, TypeError):
-            return arrow.now()
+        s = s[:-1] + "+00:00"
     try:
         return arrow.get(s)
     except (ParserError, TypeError, ValueError):
         try:
             return arrow.get(float(s))
         except (ValueError, TypeError):
-            return arrow.now()
+            return None
+
+
+def _parse_rid_timestamp(rid_ts_value) -> arrow.Arrow:
+    """Parse an RID timestamp, defaulting invalid values to the current time."""
+    return _parse_rid_timestamp_value(rid_ts_value) or arrow.now()
 
 
 @app.task(name="write_operator_rid_notification")
@@ -469,8 +474,10 @@ async def _async_stream_rid_test_data(requested_flights, test_id) -> None:
 
     provided_telemetry_duration_seconds = (end_time_of_injections - start_time_of_injections).total_seconds()
     logger.info("Provided Telemetry Duration in seconds: %s" % provided_telemetry_duration_seconds)
-    ASTM_TIME_SHIFT_SECS = 65
+    ASTM_TIME_SHIFT_SECS = 600
+    RID_STREAM_END_GRACE_SECS = 1
     astm_rid_standard_end_time = end_time_of_injections.shift(seconds=ASTM_TIME_SHIFT_SECS)
+    rid_stream_end_time = end_time_of_injections.shift(seconds=RID_STREAM_END_GRACE_SECS)
 
     position_list: list[Point] = []
     for position in all_positions:
@@ -595,7 +602,7 @@ async def _async_stream_rid_test_data(requested_flights, test_id) -> None:
         _should_stop_streaming = r.get("stop_streaming_" + test_id)
         should_stop_streaming = int(_should_stop_streaming) if _should_stop_streaming else 0
 
-        if should_stop_streaming or now > astm_rid_standard_end_time:
+        if should_stop_streaming or now > rid_stream_end_time:
             should_continue = False
             logger.info("End flight streaming ... %s", arrow.now().isoformat())
             continue

--- a/src/flight_blender/tasks/rid_task.py
+++ b/src/flight_blender/tasks/rid_task.py
@@ -19,6 +19,7 @@ from flight_blender.config import settings
 from flight_blender.db.session import async_task_session
 from flight_blender.domain_types.flight_feed import SingleRIDObservation
 from flight_blender.domain_types.rid import UASID, LatLngPoint, SignedUnsignedTelemetryObservation, UAClassificationEU
+from flight_blender.domain_types.rid_operations import RIDLatLngPoint
 from flight_blender.domain_types.rid import RIDAircraftState as LocalRIDAircraftState
 from flight_blender.domain_types.rid import RIDFlightDetails as LocalRIDFlightDetails
 from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
@@ -52,16 +53,39 @@ def _parse_rid_timestamp_us(rid_ts_value, context: str) -> int:
         logger.warning("Missing RID timestamp for {}. Defaulting sensor timestamp to 0", context)
         return 0
 
+    parsed = _parse_rid_timestamp(rid_ts_value)
     try:
-        return int(arrow.get(rid_ts_value).float_timestamp * 1_000_000)
-    except (ParserError, TypeError, ValueError) as exc:
+        return int(parsed.float_timestamp * 1_000_000)
+    except (TypeError, ValueError) as exc:
         logger.warning(
-            "Failed to parse RID timestamp {!r} for {}. Defaulting sensor timestamp to 0. Error: {}",
+            "Failed to convert RID timestamp {!r} for {}. Defaulting sensor timestamp to 0. Error: {}",
             rid_ts_value,
             context,
             exc,
         )
         return 0
+
+
+def _parse_rid_timestamp(rid_ts_value) -> arrow.Arrow:
+    """Parse an RID timestamp (RFC3339 or epoch-seconds) into an Arrow."""
+    if rid_ts_value is None:
+        return arrow.now()
+    if isinstance(rid_ts_value, (int, float)):
+        return arrow.get(rid_ts_value)
+    s = str(rid_ts_value)
+    if s.endswith("Z") and "." in s:
+        s = s[:-1]
+        try:
+            return arrow.get(float(s))
+        except (ValueError, TypeError):
+            return arrow.now()
+    try:
+        return arrow.get(s)
+    except (ParserError, TypeError, ValueError):
+        try:
+            return arrow.get(float(s))
+        except (ValueError, TypeError):
+            return arrow.now()
 
 
 @app.task(name="write_operator_rid_notification")
@@ -115,10 +139,14 @@ async def _async_process_requested_flight(
         uas_id = None
         eu_classification = None
         auth_data = None
-        if "operator_location" in fd.keys():
-            position = from_dict(data_class=LatLngPoint, data=fd["operator_location"])
+        if "operator_location" in fd.keys() and fd["operator_location"]:
+            operator_location_dict = fd["operator_location"]
+            if "position" in operator_location_dict and operator_location_dict["position"]:
+                position = from_dict(data_class=LatLngPoint, data=operator_location_dict["position"])
+            else:
+                position = from_dict(data_class=LatLngPoint, data=operator_location_dict)
             operator_location = OperatorLocation(position=position)
-        if "auth_data" in fd.keys():
+        if "auth_data" in fd.keys() and fd["auth_data"]:
             auth_data = RIDAuthData(format=fd["auth_data"]["format"], data=fd["auth_data"]["data"])
         if "uas_id" in fd.keys():
             specific_session_id = fd["uas_id"].get("specific_session_id", None)
@@ -212,18 +240,25 @@ async def _async_process_requested_flight(
         )
 
         try:
-            formatted_timestamp = arrow.get(provided_telemetry["timestamp"])
-        except (ParserError, TypeError):
+            formatted_timestamp = _parse_rid_timestamp(provided_telemetry["timestamp"])
+        except Exception:
             logger.info("Error in parsing telemetry timestamp")
             write_operator_rid_notification.delay(
                 session_id=test_id,
                 message="The mandatory timestamp provided in the telemetry is not in the correct format",
             )
+            continue
 
-        formatted_timestamp = arrow.now()
+        raw_ts = provided_telemetry["timestamp"]
+        if isinstance(raw_ts, dict):
+            ts_value = raw_ts.get("value", "")
+            ts_format = raw_ts.get("format", "RFC3339")
+        else:
+            ts_value = str(raw_ts)
+            ts_format = "RFC3339"
         try:
             telemetry_observation = RIDAircraftState(
-                timestamp=RIDTime(value=provided_telemetry["timestamp"], format="RFC3339"),
+                timestamp=RIDTime(value=ts_value, format=ts_format),
                 timestamp_accuracy=provided_telemetry["timestamp_accuracy"],
                 operational_status=provided_telemetry["operational_status"],
                 position=position,
@@ -244,7 +279,7 @@ async def _async_process_requested_flight(
 
         closest_details_response = min(
             all_flight_details,
-            key=lambda d: abs(arrow.get(d.effective_after) - formatted_timestamp),
+            key=lambda d: abs(_parse_rid_timestamp(d.effective_after) - formatted_timestamp),
         )
         flight_state_storage = RIDTestDataStorage(
             flight_state=telemetry_observation,
@@ -441,17 +476,25 @@ async def _async_stream_rid_test_data(requested_flights, test_id) -> None:
     for position in all_positions:
         position_list.append(Point(position.lng, position.lat))
 
-    multi_points = MultiPoint(position_list)
-    bounds = multi_points.minimum_rotated_rectangle.bounds
-
-    b = box(bounds[1], bounds[0], bounds[3], bounds[2])
-    co_ordinates = list(zip(*b.exterior.coords.xy))
-
-    polygon_verticies: list[LatLngPoint] = []
-    for co_ordinate in co_ordinates:
-        ll = LatLngPoint(lat=co_ordinate[0], lng=co_ordinate[1])
-        polygon_verticies.append(ll)
-    polygon_verticies.pop()
+    if len(position_list) == 1:
+        p = position_list[0]
+        padding = 0.0001
+        polygon_verticies = [
+            RIDLatLngPoint(lat=p.y - padding, lng=p.x - padding),
+            RIDLatLngPoint(lat=p.y - padding, lng=p.x + padding),
+            RIDLatLngPoint(lat=p.y + padding, lng=p.x + padding),
+            RIDLatLngPoint(lat=p.y + padding, lng=p.x - padding),
+        ]
+    else:
+        multi_points = MultiPoint(position_list)
+        bounds = multi_points.minimum_rotated_rectangle.bounds
+        b = box(bounds[1], bounds[0], bounds[3], bounds[2])
+        co_ordinates = list(zip(*b.exterior.coords.xy))
+        polygon_verticies = []
+        for co_ordinate in co_ordinates:
+            ll = LatLngPoint(lat=co_ordinate[0], lng=co_ordinate[1])
+            polygon_verticies.append(ll)
+        polygon_verticies.pop()
     outline_polygon = RIDPolygon(vertices=polygon_verticies)
     altitude_lower = RIDAltitude(value=min(all_altitudes) - 5, reference="W84", units="M")
     altitude_upper = RIDAltitude(value=min(all_altitudes) + 5, reference="W84", units="M")

--- a/testing/interuss/.env.interuss
+++ b/testing/interuss/.env.interuss
@@ -21,7 +21,7 @@ DSS_BASE_URL=http://dss1.uss1.localutm/
 DSS_SELF_AUDIENCE=flight-blender.localutm
 
 # Blender self-reference
-BLENDER_FQDN=http://flight-blender.localutm:8000
+FLIGHTBLENDER_FQDN=http://flight-blender.localutm:8000
 
 # Database (Postgres container created by this docker-compose)
 DATABASE_URL=postgres://testuser:testpass@db-blender-test:5432/testdb

--- a/testing/interuss/.env.interuss
+++ b/testing/interuss/.env.interuss
@@ -18,7 +18,7 @@ DSS_AUTH_JWKS_ENDPOINT=http://oauth.authority.localutm:8085/.well-known/jwks.jso
 
 # DSS — use the first CockroachDB-backed DSS node started by run_locally.sh
 DSS_BASE_URL=http://dss1.uss1.localutm/
-DSS_SELF_AUDIENCE=flight-blender.localutm
+DSS_SELF_AUDIENCE=dss1.uss1.localutm
 
 # Blender self-reference
 FLIGHTBLENDER_FQDN=http://flight-blender.localutm:8000

--- a/testing/interuss/.env.interuss
+++ b/testing/interuss/.env.interuss
@@ -12,6 +12,7 @@ IS_DEBUG=1
 BYPASS_AUTH_TOKEN_VERIFICATION=1
 PASSPORT_URL=http://oauth.authority.localutm:8085
 PASSPORT_AUDIENCE=flight-blender.localutm
+DSS_AUTH_URL=http://oauth.authority.localutm:8085
 DSS_AUTH_JWKS_ENDPOINT=http://oauth.authority.localutm:8085/.well-known/jwks.json
 
 # DSS — use the first CockroachDB-backed DSS node started by run_locally.sh

--- a/testing/interuss/.env.interuss
+++ b/testing/interuss/.env.interuss
@@ -13,10 +13,12 @@ BYPASS_AUTH_TOKEN_VERIFICATION=1
 PASSPORT_URL=http://oauth.authority.localutm:8085
 PASSPORT_AUDIENCE=flight-blender.localutm
 DSS_AUTH_URL=http://oauth.authority.localutm:8085
+DSS_AUTH_TOKEN_ENDPOINT=/token
 DSS_AUTH_JWKS_ENDPOINT=http://oauth.authority.localutm:8085/.well-known/jwks.json
 
 # DSS — use the first CockroachDB-backed DSS node started by run_locally.sh
 DSS_BASE_URL=http://dss1.uss1.localutm/
+DSS_SELF_AUDIENCE=flight-blender.localutm
 
 # Blender self-reference
 BLENDER_FQDN=http://flight-blender.localutm:8000

--- a/testing/interuss/scripts/run_interuss_tests.sh
+++ b/testing/interuss/scripts/run_interuss_tests.sh
@@ -244,6 +244,10 @@ SUMMARY_ARGS=()
 
 if [[ ${#SUMMARY_ARGS[@]} -gt 0 ]]; then
   python3 "${SCRIPT_DIR}/report_to_summary.py" "${SUMMARY_ARGS[@]}" || warn "report_to_summary.py failed."
+  if [[ -n "${INTERUSS_SUMMARY_FILE:-}" ]]; then
+    mkdir -p "$(dirname "${INTERUSS_SUMMARY_FILE}")"
+    python3 "${SCRIPT_DIR}/report_to_summary.py" "${SUMMARY_ARGS[@]}" > "${INTERUSS_SUMMARY_FILE}" || warn "Could not write ${INTERUSS_SUMMARY_FILE}."
+  fi
   if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     {
       echo "# InterUSS Qualification Report"

--- a/testing/interuss/scripts/run_interuss_tests.sh
+++ b/testing/interuss/scripts/run_interuss_tests.sh
@@ -54,7 +54,7 @@ separator() { echo; echo "======================================================
 
 cleanup() {
   log "Cleaning up test containers..."
-  docker compose -f "${TESTING_DIR}/docker-compose.yml" down --remove-orphans 2>/dev/null || true
+  docker compose -f "${TESTING_DIR}/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
   if [ -d "${INTERUSS_MONITORING_DIR}" ]; then
     (cd "${INTERUSS_MONITORING_DIR}" && \
       docker compose -f monitoring/mock_uss/docker-compose.yaml down --remove-orphans 2>/dev/null || true) || true

--- a/testing/interuss/scripts/run_interuss_tests.sh
+++ b/testing/interuss/scripts/run_interuss_tests.sh
@@ -1,120 +1,163 @@
 #!/usr/bin/env bash
-# run_interuss_tests.sh — Run Flight Blender against InterUSS uss_qualifier locally.
-#
-# This script replicates what the GitHub Actions workflow does, so you can run
-# the full InterUSS qualification test suite on your local machine.
-#
-# Prerequisites:
-#   - Docker installed and running
-#   - The interuss/monitoring repository cloned (or let this script do it)
-#   - ~8 GB RAM available for Docker
-#
-# Usage:
-#   cd /path/to/flight-blender
-#   bash testing/interuss/scripts/run_interuss_tests.sh [OPTIONS]
-#
-# Options:
-#   --skip-build   Skip rebuilding the flight-blender Docker image
-#   --clean        Remove all test containers and networks before starting
-#   --suite NAME   Run only one test suite: "f3548" or "netrid" (default: both)
-#   --filter EXPR  Run only test scenarios matching the filter expression.
-#                  Passed to uss_qualifier as --filter <EXPR>.
-#                  Requires --suite to be set.
-#                  Example: --suite f3548 --filter astm.f3548.v21.SCD0020
-#
-# Examples:
-#   Run everything:                     bash testing/interuss/scripts/run_interuss_tests.sh
-#   Run only F3548:                     bash testing/interuss/scripts/run_interuss_tests.sh --suite f3548
-#   Run only NetRID:                    bash testing/interuss/scripts/run_interuss_tests.sh --suite netrid
-#   Debug a single scenario (F3548):    bash testing/interuss/scripts/run_interuss_tests.sh --suite f3548 --filter astm.f3548.v21.SCD0020
-#   Skip rebuild + single suite:        bash testing/interuss/scripts/run_interuss_tests.sh --skip-build --suite netrid
-
 set -euo pipefail
 
-# ============================================================
-# Configuration
-# ============================================================
+usage() {
+  cat <<'EOF'
+Usage: bash testing/interuss/scripts/run_interuss_tests.sh [OPTIONS]
+
+Options:
+  --clean        Remove existing local test containers before starting
+  --skip-build   Reuse openutm/flight-blender-test:latest
+  --suite NAME   Run one suite: f3548 or netrid (default: both)
+  --filter EXPR  Pass a uss_qualifier scenario filter; requires --suite
+
+Examples:
+  bash testing/interuss/scripts/run_interuss_tests.sh --clean
+  bash testing/interuss/scripts/run_interuss_tests.sh --suite netrid --clean
+EOF
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 TESTING_DIR="${REPO_ROOT}/testing/interuss"
 OUTPUT_DIR="${TESTING_DIR}/output"
 CONFIGS_DIR="${TESTING_DIR}/configs"
 
-INTERUSS_MONITORING_REPO="https://github.com/interuss/monitoring.git"
-INTERUSS_MONITORING_TAG="interuss/monitoring/v0.30.0"
-INTERUSS_MONITORING_DIR="/tmp/interuss-monitoring"
-
-INTERUSS_IMAGE="interuss/monitoring:v0.30.0"
-BLENDER_IMAGE="openutm/flight-blender-test:latest"
-NETWORK="interop_ecosystem_network"
+INTERUSS_MONITORING_REPO="${INTERUSS_MONITORING_REPO:-https://github.com/interuss/monitoring.git}"
+INTERUSS_MONITORING_TAG="${INTERUSS_MONITORING_TAG:-interuss/monitoring/v0.30.0}"
+INTERUSS_MONITORING_DIR="${INTERUSS_MONITORING_DIR:-/tmp/interuss-monitoring}"
+INTERUSS_IMAGE="${INTERUSS_IMAGE:-interuss/monitoring:v0.30.0}"
+BLENDER_IMAGE="${BLENDER_IMAGE:-openutm/flight-blender-test:latest}"
+NETWORK="${NETWORK:-interop_ecosystem_network}"
 
 SKIP_BUILD=false
 CLEAN=false
 SUITE=""
 FILTER=""
 
-for arg in "$@"; do
-  case "$arg" in
-    --skip-build) SKIP_BUILD=true ;;
-    --clean)      CLEAN=true ;;
-  esac
-done
-
-# Parse --suite and --filter which need the next argument
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --skip-build|--clean) shift ;;
+    --skip-build)
+      SKIP_BUILD=true
+      shift
+      ;;
+    --clean)
+      CLEAN=true
+      shift
+      ;;
     --suite)
       SUITE="${2:-}"
-      if [ -z "${SUITE}" ]; then
-        echo "ERROR: --suite requires a value (f3548 or netrid)"
-        exit 1
-      fi
       shift 2
       ;;
     --filter)
       FILTER="${2:-}"
-      if [ -z "${FILTER}" ]; then
-        echo "ERROR: --filter requires a filter expression"
-        exit 1
-      fi
       shift 2
       ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
     *)
-      echo "ERROR: Unknown argument: $1"
-      echo "Usage: $0 [--skip-build] [--clean] [--suite f3548|netrid] [--filter EXPR]"
+      echo "ERROR: Unknown argument: $1" >&2
+      usage
       exit 1
       ;;
   esac
 done
 
-# Validate --suite value
-if [ -n "${SUITE}" ] && [ "${SUITE}" != "f3548" ] && [ "${SUITE}" != "netrid" ]; then
-  echo "ERROR: --suite must be 'f3548' or 'netrid', got '${SUITE}'"
+if [[ -n "${SUITE}" && "${SUITE}" != "f3548" && "${SUITE}" != "netrid" ]]; then
+  echo "ERROR: --suite must be f3548 or netrid, got ${SUITE}" >&2
   exit 1
 fi
-
-# --filter requires --suite
-if [ -n "${FILTER}" ] && [ -z "${SUITE}" ]; then
-  echo "ERROR: --filter requires --suite to be set"
+if [[ -n "${FILTER}" && -z "${SUITE}" ]]; then
+  echo "ERROR: --filter requires --suite" >&2
   exit 1
 fi
 
 RUN_F3548=true
 RUN_NETRID=true
-if [ "${SUITE}" = "f3548" ]; then
-  RUN_NETRID=false
-elif [ "${SUITE}" = "netrid" ]; then
-  RUN_F3548=false
-fi
+[[ "${SUITE}" == "f3548" ]] && RUN_NETRID=false
+[[ "${SUITE}" == "netrid" ]] && RUN_F3548=false
 
-# ============================================================
-# Helpers
-# ============================================================
 log() { echo "[$(date +%T)] $*"; }
-separator() { echo; echo "======================================================"; echo "  $*"; echo "======================================================"; echo; }
+warn() {
+  log "WARNING: $*"
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::warning::$*"
+  fi
+}
+section() { printf '\n======================================================\n  %s\n======================================================\n\n' "$*"; }
 
-separator "Configuration"
+CLEANED_UP=false
+cleanup() {
+  [[ "${CLEANED_UP}" == "true" ]] && return
+  CLEANED_UP=true
+  log "Cleaning up test containers..."
+  docker compose -f "${TESTING_DIR}/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
+  if [[ -d "${INTERUSS_MONITORING_DIR}" ]]; then
+    (cd "${INTERUSS_MONITORING_DIR}" && docker compose -f monitoring/mock_uss/docker-compose.yaml down --remove-orphans 2>/dev/null) || true
+    (cd "${INTERUSS_MONITORING_DIR}" && NUM_USS=2 ./build/dev/run_locally.sh down 2>/dev/null) || true
+  fi
+  docker network rm "${NETWORK}" 2>/dev/null || true
+  log "Cleanup done."
+}
+trap cleanup EXIT
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-60}"
+  local status
+
+  log "Waiting for ${url} ..."
+  for i in $(seq 1 "${attempts}"); do
+    status="$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "${url}" 2>/dev/null || true)"
+    status="${status:-000}"
+    if [[ "${status}" != "000" ]]; then
+      log "${url} is up (HTTP ${status})."
+      return 0
+    fi
+    sleep 3
+  done
+
+  log "ERROR: ${url} did not become ready after ${attempts} attempts."
+  return 1
+}
+
+run_qualifier() {
+  local name="$1"
+  local config="$2"
+  local output_path="$3"
+  local auth_spec_2="${4:-}"
+  local -a cmd=(
+    docker run --rm
+    --network "${NETWORK}"
+    --add-host "host.docker.internal:host-gateway"
+    -w /app/monitoring/uss_qualifier
+    -e "AUTH_SPEC=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)"
+  )
+
+  if [[ -n "${auth_spec_2}" ]]; then
+    cmd+=(-e "AUTH_SPEC_2=${auth_spec_2}")
+  fi
+
+  cmd+=(
+    -v "${CONFIGS_DIR}:/configs:ro"
+    -v "${OUTPUT_DIR}:/app/monitoring/uss_qualifier/output"
+    "${INTERUSS_IMAGE}"
+    uv run main.py
+    --config "file:///configs/${config}"
+    --output-path "output/${output_path}"
+  )
+
+  if [[ -n "${FILTER}" ]]; then
+    cmd+=(--filter "${FILTER}")
+  fi
+
+  section "uss_qualifier: ${name}"
+  "${cmd[@]}"
+}
+
+section "Configuration"
 log "Skip build:      ${SKIP_BUILD}"
 log "Clean mode:      ${CLEAN}"
 log "Suite:           ${SUITE:-both}"
@@ -122,250 +165,110 @@ log "Filter:          ${FILTER:-all}"
 log "Will run F3548:  ${RUN_F3548}"
 log "Will run NetRID: ${RUN_NETRID}"
 
-cleanup() {
-  log "Cleaning up test containers..."
-  docker compose -f "${TESTING_DIR}/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
-  if [ -d "${INTERUSS_MONITORING_DIR}" ]; then
-    (cd "${INTERUSS_MONITORING_DIR}" && \
-      docker compose -f monitoring/mock_uss/docker-compose.yaml down --remove-orphans 2>/dev/null || true) || true
-    (cd "${INTERUSS_MONITORING_DIR}" && \
-      NUM_USS=2 ./build/dev/run_locally.sh down 2>/dev/null || true) || true
-  fi
-  log "Cleanup done."
-}
-
-wait_for_http() {
-  local url="$1"
-  local max_attempts="${2:-60}"
-  local attempt=0
-  log "Waiting for ${url} ..."
-  until [ "$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "${url}" 2>/dev/null || echo "000")" != "000" ]; do
-    attempt=$((attempt + 1))
-    if [ "${attempt}" -ge "${max_attempts}" ]; then
-      log "ERROR: ${url} did not become ready after ${max_attempts} attempts."
-      return 1
-    fi
-    sleep 3
-  done
-  log "${url} is up."
-}
-
-# ============================================================
-# Preflight checks
-# ============================================================
-separator "Preflight checks"
+section "Preflight checks"
 command -v docker >/dev/null 2>&1 || { log "ERROR: Docker is not installed."; exit 1; }
-docker info >/dev/null 2>&1       || { log "ERROR: Docker is not running."; exit 1; }
+docker info >/dev/null 2>&1 || { log "ERROR: Docker is not running."; exit 1; }
 log "Docker OK."
 
-# ============================================================
-# Optional clean
-# ============================================================
-if [ "${CLEAN}" = "true" ]; then
-  separator "Clean mode — removing existing test containers"
+if [[ "${CLEAN}" == "true" ]]; then
+  section "Clean"
   cleanup
-  docker network rm "${NETWORK}" 2>/dev/null || true
+  CLEANED_UP=false
 fi
 
-# ============================================================
-# Prepare output directory
-# ============================================================
 mkdir -p "${OUTPUT_DIR}"
 chmod 777 "${OUTPUT_DIR}"
 log "Output directory: ${OUTPUT_DIR}"
 
-# ============================================================
-# Create Docker network
-# ============================================================
-separator "Docker network"
-if ! docker network inspect "${NETWORK}" >/dev/null 2>&1; then
-  log "Creating network ${NETWORK} ..."
-  docker network create "${NETWORK}"
-else
-  log "Network ${NETWORK} already exists."
-fi
+section "Docker network"
+docker network inspect "${NETWORK}" >/dev/null 2>&1 || docker network create "${NETWORK}"
 
-# ============================================================
-# Clone / update interuss/monitoring
-# ============================================================
-separator "InterUSS monitoring repo"
-if [ -d "${INTERUSS_MONITORING_DIR}/.git" ]; then
+section "InterUSS monitoring"
+if [[ ! -d "${INTERUSS_MONITORING_DIR}/.git" ]]; then
+  git clone --depth=1 --branch "${INTERUSS_MONITORING_TAG}" "${INTERUSS_MONITORING_REPO}" "${INTERUSS_MONITORING_DIR}"
+else
   log "Using existing clone at ${INTERUSS_MONITORING_DIR}"
-else
-  log "Cloning ${INTERUSS_MONITORING_REPO} at tag ${INTERUSS_MONITORING_TAG} ..."
-  git clone --depth=1 --branch "${INTERUSS_MONITORING_TAG}" \
-    "${INTERUSS_MONITORING_REPO}" "${INTERUSS_MONITORING_DIR}"
 fi
+docker pull "${INTERUSS_IMAGE}" || warn "Could not pull ${INTERUSS_IMAGE}; using cached image if available."
 
-# Pull the monitoring image upfront so startup is faster
-log "Pulling ${INTERUSS_IMAGE} ..."
-docker pull "${INTERUSS_IMAGE}" || log "WARNING: Could not pull ${INTERUSS_IMAGE} (will use cached)"
+section "DSS ecosystem"
+(cd "${INTERUSS_MONITORING_DIR}" && NUM_USS=2 ./build/dev/run_locally.sh up -d)
+wait_for_http "http://localhost:8085/.well-known/jwks.json" 60 || wait_for_http "http://localhost:8085/" 10
 
-# ============================================================
-# Start DSS ecosystem (CockroachDB + DSS + dummy OAuth)
-# ============================================================
-separator "Starting DSS ecosystem"
-(
-  cd "${INTERUSS_MONITORING_DIR}"
-  log "Starting DSS (NUM_USS=2) ..."
-  NUM_USS=2 ./build/dev/run_locally.sh up -d
-)
-log "Waiting for dummy OAuth ..."
-wait_for_http "http://localhost:8085/.well-known/jwks.json" 60 \
-  || { log "ERROR: OAuth not ready. Check DSS ecosystem."; cleanup; exit 1; }
-log "DSS ecosystem is ready."
-
-# ============================================================
-# Build Flight Blender image (unless --skip-build)
-# ============================================================
-separator "Flight Blender image"
-if [ "${SKIP_BUILD}" = "false" ]; then
-  log "Building ${BLENDER_IMAGE} from ${REPO_ROOT} ..."
+section "Flight Blender image"
+if [[ "${SKIP_BUILD}" == "false" ]]; then
   docker build -t "${BLENDER_IMAGE}" "${REPO_ROOT}"
 else
   log "Skipping build (--skip-build)."
 fi
 
-# ============================================================
-# Start Flight Blender stack
-# ============================================================
-separator "Starting Flight Blender"
-log "Starting Flight Blender containers ..."
+section "Flight Blender stack"
 docker compose -f "${TESTING_DIR}/docker-compose.yml" up -d
+wait_for_http "http://localhost:8000/scd/flight_planning/status" 90 || wait_for_http "http://localhost:8000/rid/capabilities" 30 || true
 
-log "Waiting for Flight Blender health check ..."
-# Django returns 400/401 on unauthenticated requests — that's still "up"
-wait_for_http "http://localhost:8000/scd/flight_planning/status" 90 \
-  || wait_for_http "http://localhost:8000/rid/capabilities" 30 \
-  || log "WARNING: Flight Blender health check did not pass (will continue)"
-
-# ============================================================
-# Start mock_uss instances
-# ============================================================
-separator "Starting mock USS instances"
+section "mock_uss"
 (
   cd "${INTERUSS_MONITORING_DIR}"
-  log "Starting mock_uss (scd + ridsp + riddp profiles) ..."
-  UID_GID="$(id -u):$(id -g)" \
-  docker compose -f monitoring/mock_uss/docker-compose.yaml up -d \
+  UID_GID="$(id -u):$(id -g)" docker compose -f monitoring/mock_uss/docker-compose.yaml up -d \
     mock_uss_scdsc_a mock_uss_scdsc_b mock_uss_scdsc_interaction_log \
-    mock_uss_ridsp mock_uss_riddp \
-    2>/dev/null || true
-)
-# Brief pause to let mock_uss settle
+    mock_uss_ridsp mock_uss_riddp
+) || warn "mock_uss startup had issues; continuing."
 sleep 10
 
-# ============================================================
-# Run uss_qualifier — F3548-21
-# ============================================================
 F3548_RC=0
-if [ "${RUN_F3548}" = "true" ]; then
-  separator "uss_qualifier: F3548-21 (Strategic Conflict Detection)"
-
-  F3548_CMD=(
-    docker run --rm
-    --network "${NETWORK}"
-    --add-host "host.docker.internal:host-gateway"
-    -w /app/monitoring/uss_qualifier
-    -e "AUTH_SPEC=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)"
-    -e "AUTH_SPEC_2=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier_2)"
-    -v "${CONFIGS_DIR}:/configs:ro"
-    -v "${OUTPUT_DIR}:/app/monitoring/uss_qualifier/output"
-    "${INTERUSS_IMAGE}"
-    uv run main.py
-    --config "file:///configs/f3548_flight_blender.yaml"
-    --output-path "output/f3548"
-  )
-
-  if [ -n "${FILTER}" ]; then
-    F3548_CMD+=(--filter "${FILTER}")
-    log "Filtering to: ${FILTER}"
-  fi
-
-  "${F3548_CMD[@]}" || F3548_RC=$?
-
-  log "F3548-21 uss_qualifier finished (exit code: ${F3548_RC})."
-else
-  separator "Skipping F3548-21 (--suite netrid)"
-fi
-
-# ============================================================
-# Run uss_qualifier — NetRID v22a
-# ============================================================
 NETRID_RC=0
-if [ "${RUN_NETRID}" = "true" ]; then
-  separator "uss_qualifier: NetRID v22a (Remote ID F3411-22a)"
 
-  NETRID_CMD=(
-    docker run --rm
-    --network "${NETWORK}"
-    --add-host "host.docker.internal:host-gateway"
-    -w /app/monitoring/uss_qualifier
-    -e "AUTH_SPEC=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)"
-    -v "${CONFIGS_DIR}:/configs:ro"
-    -v "${OUTPUT_DIR}:/app/monitoring/uss_qualifier/output"
-    "${INTERUSS_IMAGE}"
-    uv run main.py
-    --config "file:///configs/netrid_v22a_flight_blender.yaml"
-    --output-path "output/netrid_v22a"
-  )
-
-  if [ -n "${FILTER}" ]; then
-    NETRID_CMD+=(--filter "${FILTER}")
-    log "Filtering to: ${FILTER}"
-  fi
-
-  "${NETRID_CMD[@]}" || NETRID_RC=$?
-
-  log "NetRID v22a uss_qualifier finished (exit code: ${NETRID_RC})."
+if [[ "${RUN_F3548}" == "true" ]]; then
+  run_qualifier \
+    "F3548-21 (Strategic Conflict Detection)" \
+    "f3548_flight_blender.yaml" \
+    "f3548" \
+    "DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier_2)" || F3548_RC=$?
 else
-  separator "Skipping NetRID v22a (--suite f3548)"
+  section "Skipping F3548-21"
 fi
 
-# ============================================================
-# Generate summary
-# ============================================================
-separator "Test summary"
+if [[ "${RUN_NETRID}" == "true" ]]; then
+  run_qualifier \
+    "NetRID v22a (Remote ID F3411-22a)" \
+    "netrid_v22a_flight_blender.yaml" \
+    "netrid_v22a" || NETRID_RC=$?
+else
+  section "Skipping NetRID v22a"
+fi
 
+section "Test summary"
 SUMMARY_ARGS=()
-if [ "${RUN_F3548}" = "true" ] && [ -f "${OUTPUT_DIR}/f3548/report.json" ]; then
-  SUMMARY_ARGS+=("${OUTPUT_DIR}/f3548/report.json")
-fi
-if [ "${RUN_NETRID}" = "true" ] && [ -f "${OUTPUT_DIR}/netrid_v22a/report.json" ]; then
-  SUMMARY_ARGS+=("${OUTPUT_DIR}/netrid_v22a/report.json")
-fi
+[[ "${RUN_F3548}" == "true" && -f "${OUTPUT_DIR}/f3548/report.json" ]] && SUMMARY_ARGS+=("${OUTPUT_DIR}/f3548/report.json")
+[[ "${RUN_NETRID}" == "true" && -f "${OUTPUT_DIR}/netrid_v22a/report.json" ]] && SUMMARY_ARGS+=("${OUTPUT_DIR}/netrid_v22a/report.json")
 
-if [ ${#SUMMARY_ARGS[@]} -gt 0 ]; then
-  python3 "${SCRIPT_DIR}/report_to_summary.py" "${SUMMARY_ARGS[@]}" \
-    2>/dev/null || log "WARNING: report_to_summary.py failed (reports may be incomplete)"
+if [[ ${#SUMMARY_ARGS[@]} -gt 0 ]]; then
+  python3 "${SCRIPT_DIR}/report_to_summary.py" "${SUMMARY_ARGS[@]}" || warn "report_to_summary.py failed."
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "# InterUSS Qualification Report"
+      echo
+      python3 "${SCRIPT_DIR}/report_to_summary.py" "${SUMMARY_ARGS[@]}" || true
+    } >> "${GITHUB_STEP_SUMMARY}"
+  fi
 else
-  log "No report files found — skipping summary."
+  log "No report files found; skipping summary."
 fi
 
 echo
 log "Reports written to: ${OUTPUT_DIR}/"
 ls -lh "${OUTPUT_DIR}/" 2>/dev/null || true
 
-# ============================================================
-# Teardown
-# ============================================================
-separator "Stopping test containers"
-cleanup
-
-# ============================================================
-# Exit
-# ============================================================
-if [ "${RUN_F3548}" = "true" ] && [ "${F3548_RC}" -ne 0 ]; then
-  log "F3548-21 run had failures (exit code: ${F3548_RC}). Review ${OUTPUT_DIR}/f3548/ for details."
+if [[ "${F3548_RC}" -ne 0 ]]; then
+  warn "F3548-21 uss_qualifier exited with ${F3548_RC}; reports were still generated when available."
 fi
-if [ "${RUN_NETRID}" = "true" ] && [ "${NETRID_RC}" -ne 0 ]; then
-  log "NetRID v22a run had failures (exit code: ${NETRID_RC}). Review ${OUTPUT_DIR}/netrid_v22a/ for details."
+if [[ "${NETRID_RC}" -ne 0 ]]; then
+  warn "NetRID v22a uss_qualifier exited with ${NETRID_RC}; reports were still generated when available."
 fi
 
-if [ "${RUN_F3548}" = "true" ] && [ "${F3548_RC}" -ne 0 ] || \
-   [ "${RUN_NETRID}" = "true" ] && [ "${NETRID_RC}" -ne 0 ]; then
-  log "This is expected until Flight Blender fully implements all requirements."
-  exit 0  # Always exit 0 — failures are captured in the reports
+if [[ "${F3548_RC}" -ne 0 || "${NETRID_RC}" -ne 0 ]]; then
+  warn "uss_qualifier command failures are treated as warnings; inspect the uploaded reports for details."
+  exit 0
 fi
 
 log "All uss_qualifier runs completed successfully."

--- a/testing/interuss/scripts/run_interuss_tests.sh
+++ b/testing/interuss/scripts/run_interuss_tests.sh
@@ -110,7 +110,7 @@ log "Output directory: ${OUTPUT_DIR}"
 separator "Docker network"
 if ! docker network inspect "${NETWORK}" >/dev/null 2>&1; then
   log "Creating network ${NETWORK} ..."
-  docker network create --subnet=172.27.0.0/16 "${NETWORK}"
+  docker network create "${NETWORK}"
 else
   log "Network ${NETWORK} already exists."
 fi

--- a/testing/interuss/scripts/run_interuss_tests.sh
+++ b/testing/interuss/scripts/run_interuss_tests.sh
@@ -11,11 +11,23 @@
 #
 # Usage:
 #   cd /path/to/flight-blender
-#   bash testing/interuss/scripts/run_interuss_tests.sh [--skip-build] [--clean]
+#   bash testing/interuss/scripts/run_interuss_tests.sh [OPTIONS]
 #
 # Options:
 #   --skip-build   Skip rebuilding the flight-blender Docker image
 #   --clean        Remove all test containers and networks before starting
+#   --suite NAME   Run only one test suite: "f3548" or "netrid" (default: both)
+#   --filter EXPR  Run only test scenarios matching the filter expression.
+#                  Passed to uss_qualifier as --filter <EXPR>.
+#                  Requires --suite to be set.
+#                  Example: --suite f3548 --filter astm.f3548.v21.SCD0020
+#
+# Examples:
+#   Run everything:                     bash testing/interuss/scripts/run_interuss_tests.sh
+#   Run only F3548:                     bash testing/interuss/scripts/run_interuss_tests.sh --suite f3548
+#   Run only NetRID:                    bash testing/interuss/scripts/run_interuss_tests.sh --suite netrid
+#   Debug a single scenario (F3548):    bash testing/interuss/scripts/run_interuss_tests.sh --suite f3548 --filter astm.f3548.v21.SCD0020
+#   Skip rebuild + single suite:        bash testing/interuss/scripts/run_interuss_tests.sh --skip-build --suite netrid
 
 set -euo pipefail
 
@@ -38,6 +50,8 @@ NETWORK="interop_ecosystem_network"
 
 SKIP_BUILD=false
 CLEAN=false
+SUITE=""
+FILTER=""
 
 for arg in "$@"; do
   case "$arg" in
@@ -46,11 +60,67 @@ for arg in "$@"; do
   esac
 done
 
+# Parse --suite and --filter which need the next argument
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-build|--clean) shift ;;
+    --suite)
+      SUITE="${2:-}"
+      if [ -z "${SUITE}" ]; then
+        echo "ERROR: --suite requires a value (f3548 or netrid)"
+        exit 1
+      fi
+      shift 2
+      ;;
+    --filter)
+      FILTER="${2:-}"
+      if [ -z "${FILTER}" ]; then
+        echo "ERROR: --filter requires a filter expression"
+        exit 1
+      fi
+      shift 2
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1"
+      echo "Usage: $0 [--skip-build] [--clean] [--suite f3548|netrid] [--filter EXPR]"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate --suite value
+if [ -n "${SUITE}" ] && [ "${SUITE}" != "f3548" ] && [ "${SUITE}" != "netrid" ]; then
+  echo "ERROR: --suite must be 'f3548' or 'netrid', got '${SUITE}'"
+  exit 1
+fi
+
+# --filter requires --suite
+if [ -n "${FILTER}" ] && [ -z "${SUITE}" ]; then
+  echo "ERROR: --filter requires --suite to be set"
+  exit 1
+fi
+
+RUN_F3548=true
+RUN_NETRID=true
+if [ "${SUITE}" = "f3548" ]; then
+  RUN_NETRID=false
+elif [ "${SUITE}" = "netrid" ]; then
+  RUN_F3548=false
+fi
+
 # ============================================================
 # Helpers
 # ============================================================
 log() { echo "[$(date +%T)] $*"; }
 separator() { echo; echo "======================================================"; echo "  $*"; echo "======================================================"; echo; }
+
+separator "Configuration"
+log "Skip build:      ${SKIP_BUILD}"
+log "Clean mode:      ${CLEAN}"
+log "Suite:           ${SUITE:-both}"
+log "Filter:          ${FILTER:-all}"
+log "Will run F3548:  ${RUN_F3548}"
+log "Will run NetRID: ${RUN_NETRID}"
 
 cleanup() {
   log "Cleaning up test containers..."
@@ -188,52 +258,89 @@ sleep 10
 # ============================================================
 # Run uss_qualifier — F3548-21
 # ============================================================
-separator "uss_qualifier: F3548-21 (Strategic Conflict Detection)"
 F3548_RC=0
-docker run --rm \
-  --network "${NETWORK}" \
-  --add-host "host.docker.internal:host-gateway" \
-  -w /app/monitoring/uss_qualifier \
-  -e "AUTH_SPEC=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)" \
-  -e "AUTH_SPEC_2=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier_2)" \
-  -v "${CONFIGS_DIR}:/configs:ro" \
-  -v "${OUTPUT_DIR}:/app/monitoring/uss_qualifier/output" \
-  "${INTERUSS_IMAGE}" \
-  uv run main.py \
-    --config "file:///configs/f3548_flight_blender.yaml" \
-    --output-path "output/f3548" \
-  || F3548_RC=$?
+if [ "${RUN_F3548}" = "true" ]; then
+  separator "uss_qualifier: F3548-21 (Strategic Conflict Detection)"
 
-log "F3548-21 uss_qualifier finished (exit code: ${F3548_RC})."
+  F3548_CMD=(
+    docker run --rm
+    --network "${NETWORK}"
+    --add-host "host.docker.internal:host-gateway"
+    -w /app/monitoring/uss_qualifier
+    -e "AUTH_SPEC=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)"
+    -e "AUTH_SPEC_2=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier_2)"
+    -v "${CONFIGS_DIR}:/configs:ro"
+    -v "${OUTPUT_DIR}:/app/monitoring/uss_qualifier/output"
+    "${INTERUSS_IMAGE}"
+    uv run main.py
+    --config "file:///configs/f3548_flight_blender.yaml"
+    --output-path "output/f3548"
+  )
+
+  if [ -n "${FILTER}" ]; then
+    F3548_CMD+=(--filter "${FILTER}")
+    log "Filtering to: ${FILTER}"
+  fi
+
+  "${F3548_CMD[@]}" || F3548_RC=$?
+
+  log "F3548-21 uss_qualifier finished (exit code: ${F3548_RC})."
+else
+  separator "Skipping F3548-21 (--suite netrid)"
+fi
 
 # ============================================================
 # Run uss_qualifier — NetRID v22a
 # ============================================================
-separator "uss_qualifier: NetRID v22a (Remote ID F3411-22a)"
 NETRID_RC=0
-docker run --rm \
-  --network "${NETWORK}" \
-  --add-host "host.docker.internal:host-gateway" \
-  -w /app/monitoring/uss_qualifier \
-  -e "AUTH_SPEC=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)" \
-  -v "${CONFIGS_DIR}:/configs:ro" \
-  -v "${OUTPUT_DIR}:/app/monitoring/uss_qualifier/output" \
-  "${INTERUSS_IMAGE}" \
-  uv run main.py \
-    --config "file:///configs/netrid_v22a_flight_blender.yaml" \
-    --output-path "output/netrid_v22a" \
-  || NETRID_RC=$?
+if [ "${RUN_NETRID}" = "true" ]; then
+  separator "uss_qualifier: NetRID v22a (Remote ID F3411-22a)"
 
-log "NetRID v22a uss_qualifier finished (exit code: ${NETRID_RC})."
+  NETRID_CMD=(
+    docker run --rm
+    --network "${NETWORK}"
+    --add-host "host.docker.internal:host-gateway"
+    -w /app/monitoring/uss_qualifier
+    -e "AUTH_SPEC=DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)"
+    -v "${CONFIGS_DIR}:/configs:ro"
+    -v "${OUTPUT_DIR}:/app/monitoring/uss_qualifier/output"
+    "${INTERUSS_IMAGE}"
+    uv run main.py
+    --config "file:///configs/netrid_v22a_flight_blender.yaml"
+    --output-path "output/netrid_v22a"
+  )
+
+  if [ -n "${FILTER}" ]; then
+    NETRID_CMD+=(--filter "${FILTER}")
+    log "Filtering to: ${FILTER}"
+  fi
+
+  "${NETRID_CMD[@]}" || NETRID_RC=$?
+
+  log "NetRID v22a uss_qualifier finished (exit code: ${NETRID_RC})."
+else
+  separator "Skipping NetRID v22a (--suite f3548)"
+fi
 
 # ============================================================
 # Generate summary
 # ============================================================
 separator "Test summary"
-python3 "${SCRIPT_DIR}/report_to_summary.py" \
-  "${OUTPUT_DIR}/f3548/report.json" \
-  "${OUTPUT_DIR}/netrid_v22a/report.json" \
-  2>/dev/null || log "WARNING: report_to_summary.py failed (reports may be incomplete)"
+
+SUMMARY_ARGS=()
+if [ "${RUN_F3548}" = "true" ] && [ -f "${OUTPUT_DIR}/f3548/report.json" ]; then
+  SUMMARY_ARGS+=("${OUTPUT_DIR}/f3548/report.json")
+fi
+if [ "${RUN_NETRID}" = "true" ] && [ -f "${OUTPUT_DIR}/netrid_v22a/report.json" ]; then
+  SUMMARY_ARGS+=("${OUTPUT_DIR}/netrid_v22a/report.json")
+fi
+
+if [ ${#SUMMARY_ARGS[@]} -gt 0 ]; then
+  python3 "${SCRIPT_DIR}/report_to_summary.py" "${SUMMARY_ARGS[@]}" \
+    2>/dev/null || log "WARNING: report_to_summary.py failed (reports may be incomplete)"
+else
+  log "No report files found — skipping summary."
+fi
 
 echo
 log "Reports written to: ${OUTPUT_DIR}/"
@@ -248,11 +355,17 @@ cleanup
 # ============================================================
 # Exit
 # ============================================================
-if [ "${F3548_RC}" -ne 0 ] || [ "${NETRID_RC}" -ne 0 ]; then
-  log "One or more test runs had failures (f3548=${F3548_RC}, netrid=${NETRID_RC})."
+if [ "${RUN_F3548}" = "true" ] && [ "${F3548_RC}" -ne 0 ]; then
+  log "F3548-21 run had failures (exit code: ${F3548_RC}). Review ${OUTPUT_DIR}/f3548/ for details."
+fi
+if [ "${RUN_NETRID}" = "true" ] && [ "${NETRID_RC}" -ne 0 ]; then
+  log "NetRID v22a run had failures (exit code: ${NETRID_RC}). Review ${OUTPUT_DIR}/netrid_v22a/ for details."
+fi
+
+if [ "${RUN_F3548}" = "true" ] && [ "${F3548_RC}" -ne 0 ] || \
+   [ "${RUN_NETRID}" = "true" ] && [ "${NETRID_RC}" -ne 0 ]; then
   log "This is expected until Flight Blender fully implements all requirements."
-  log "Review the reports in ${OUTPUT_DIR}/ for details."
-  exit 0  # Always exit 0 from this script — failures are captured in the reports
+  exit 0  # Always exit 0 — failures are captured in the reports
 fi
 
 log "All uss_qualifier runs completed successfully."


### PR DESCRIPTION
## Summary
- Add ASTM/interUSS versioning support and tighten SCD planning/DSS client behavior for F3548 qualification.
- Fix NetRID v22a SP behavior, including USS flight response shaping, RID timestamp parsing, telemetry retention, and ISA timing.
- Simplify the InterUSS qualification workflow to call the repo runner script directly and run on every PR.
- Update the InterUSS runner script with shared suite execution, cleanup-on-exit, GitHub step summaries, and warning annotations for nonzero qualifier process exits.
- Add an InterUSS analysis runbook for local qualifier debugging.

## Verification
- `uv run pytest tests/test_rid_tasks.py::TestParseRidTimestampUs::test_invalid_string_returns_zero -q`
- `uv run ruff check src/flight_blender/tasks/rid_task.py`
- `bash -n testing/interuss/scripts/run_interuss_tests.sh`
- `testing/interuss/scripts/run_interuss_tests.sh --help`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/interuss-qualification.yml'); puts 'yaml ok'"`
- `bash testing/interuss/scripts/run_interuss_tests.sh --suite netrid --clean` (NetRID v22a: 10581 passed, 0 failed)

## Notes
- F3548 DSS public addressability failures are expected in the local Docker environment.
- Qualification reports are uploaded as workflow artifacts; nonzero qualifier process exits are surfaced as warnings rather than failing the GitHub job.
