### PR TITLE
refactor(tasks): remove forbidden repository/model imports from task modules

### DIFF
--- a/src/flight_blender/clients/dss_constraint_client.py
+++ b/src/flight_blender/clients/dss_constraint_client.py
@@ -2,6 +2,7 @@ import json
 import uuid
 from dataclasses import asdict
 from enum import Enum
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests
@@ -12,14 +13,15 @@ from loguru import logger
 from flight_blender.auth.dss_auth import get_dss_auth_token
 from flight_blender.auth.token_audience import generate_audience_from_base_url
 from flight_blender.config import settings
-from flight_blender.db.session import async_task_session
 from flight_blender.domain_types.constraint import Constraint, ConstraintDetails, ConstraintReference, QueryConstraintsPayload
 from flight_blender.domain_types.scd import Time, Volume4D
-from flight_blender.repositories.constraint_repo import SQLAlchemyConstraintRepository
+
+if TYPE_CHECKING:
+    from flight_blender.repositories.constraint_repo import SQLAlchemyConstraintRepository
 
 
 class ConstraintOperations:
-    def __init__(self, constraint_repo: SQLAlchemyConstraintRepository | None = None):
+    def __init__(self, constraint_repo: "SQLAlchemyConstraintRepository | None" = None):
         self.dss_base_url = settings.DSS_BASE_URL
         self.constraint_repo = constraint_repo
 
@@ -91,11 +93,7 @@ class ConstraintOperations:
                     if self.constraint_repo is not None:
                         constraint_repo = self.constraint_repo
                     else:
-                        from flight_blender.repositories.constraint_repo import SQLAlchemyConstraintRepository  # noqa: PLC0415
-
-                        _db_ctx = async_task_session()
-                        db = await _db_ctx.__aenter__()
-                        constraint_repo = SQLAlchemyConstraintRepository(db)
+                        raise ValueError("constraint_repo must be provided for local constraint queries")
                     db_constraint_reference = await constraint_repo.get_constraint_reference_by_id(uuid.UUID(str(_constraint_reference.id)))
                     constraints_reference_exists = db_constraint_reference is not None
 

--- a/src/flight_blender/clients/dss_rid_client.py
+++ b/src/flight_blender/clients/dss_rid_client.py
@@ -9,6 +9,7 @@ import math
 import uuid
 from dataclasses import asdict
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 import requests
 import tldextract
@@ -21,7 +22,6 @@ from uas_standards.astm.f3411.v22a.constants import NetMinClusterSizePercent, Ne
 from flight_blender.auth import dss_auth as dss_auth_helper
 from flight_blender.auth.token_cache import get_redis
 from flight_blender.config import settings
-from flight_blender.db.session import async_task_session
 from flight_blender.domain_types.common import RESPONSE_CONTENT_TYPE
 from flight_blender.domain_types.rid_operations import (
     Cluster,
@@ -44,7 +44,9 @@ from flight_blender.domain_types.rid_operations import (
     SubscriptionState,
 )
 from flight_blender.domain_types.scd import Volume4D
-from flight_blender.repositories.rid_repo import SQLAlchemyRIDRepository
+
+if TYPE_CHECKING:
+    from flight_blender.repositories.rid_repo import SQLAlchemyRIDRepository
 
 geod = Geod(ellps="WGS84")
 
@@ -310,6 +312,7 @@ class RemoteIDOperations:
         request_uuid,
         subscription_duration_seconds: int = 30,
         is_simulated: bool = False,
+        rid_repo: "SQLAlchemyRIDRepository | None" = None,
     ) -> SubscriptionResponse:
         """This method PUTS /dss/subscriptions"""
         subscription_response = SubscriptionResponse(created=False, dss_subscription_id=None, notification_index=0)
@@ -407,17 +410,17 @@ class RemoteIDOperations:
                 )
 
                 async def _write_subscription() -> None:
-                    async with async_task_session() as db:
-                        rid_repo = SQLAlchemyRIDRepository(db)
-                        await rid_repo.create_subscription(
-                            subscription_id=subscription_id,
-                            record_id=uuid.UUID(request_uuid) if isinstance(request_uuid, str) else request_uuid,
-                            view_hash=view_hash,
-                            end_datetime=fifteen_seconds_from_now_isoformat,
-                            is_simulated=is_simulated,
-                            view=view,
-                            flights_dict=flights_dict_str,
-                        )
+                    if rid_repo is None:
+                        raise ValueError("rid_repo must be provided")
+                    await rid_repo.create_subscription(
+                        subscription_id=subscription_id,
+                        record_id=uuid.UUID(request_uuid) if isinstance(request_uuid, str) else request_uuid,
+                        view_hash=view_hash,
+                        end_datetime=fifteen_seconds_from_now_isoformat,
+                        is_simulated=is_simulated,
+                        view=view,
+                        flights_dict=flights_dict_str,
+                    )
 
                 asyncio.run(_write_subscription())
 

--- a/src/flight_blender/clients/dss_scd_client.py
+++ b/src/flight_blender/clients/dss_scd_client.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import uuid
 from dataclasses import asdict
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import arrow
 import httpx
@@ -68,11 +68,13 @@ from flight_blender.domain_types.scd import (
     Volume4D,
 )
 from flight_blender.domain_types.scd import Polygon as Plgn
-from flight_blender.repositories.constraint_repo import SQLAlchemyConstraintRepository
-from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
 from flight_blender.utils import spatial_rid as rtree_helper
 from flight_blender.utils.json_codecs import LazyEncoder
 from flight_blender.utils.scd_helpers import PeerOperationalIntentValidator, VolumesConverter
+
+if TYPE_CHECKING:
+    from flight_blender.repositories.constraint_repo import SQLAlchemyConstraintRepository
+    from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
 
 HTTP_TIMEOUT_SECONDS = 30.0
 
@@ -114,7 +116,12 @@ class OperationalIntentReferenceHelper:
     A class to parse Operational Intent References into Dataclass objects
     """
 
-    async def parse_stored_operational_intent_details(self, operation_id: str) -> None | OperationalIntentStorage:
+    def __init__(self, fd_repo: "SQLAlchemyFlightDeclarationRepository | None" = None):
+        self.fd_repo = fd_repo
+
+    async def parse_stored_operational_intent_details(
+        self, operation_id: str, fd_repo: "SQLAlchemyFlightDeclarationRepository | None" = None
+    ) -> None | OperationalIntentStorage:
         """
         Parses and retrieves stored operational intent details for a given operation ID.
         This method interacts with the database to fetch operational intent details,
@@ -123,6 +130,7 @@ class OperationalIntentReferenceHelper:
         Args:
             operation_id (str): The unique identifier of the operation for which
                                 the operational intent details are to be retrieved.
+            fd_repo (SQLAlchemyFlightDeclarationRepository | None): Repository instance. If None, uses self.fd_repo.
         Returns:
             Union[None, OperationalIntentStorage]:
                 - An instance of `OperationalIntentStorage` containing the parsed operational intent details
@@ -139,16 +147,19 @@ class OperationalIntentReferenceHelper:
               time intervals, altitude limits, and success response details.
         """
 
+        repo = fd_repo or self.fd_repo
+        if not repo:
+            raise ValueError("fd_repo must be provided either in __init__ or as method parameter")
+
         async with async_task_session() as db:
-            fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-            flight_operational_intent_reference = await fd_repo.get_opint_reference_by_declaration_id(uuid.UUID(operation_id))
+            flight_operational_intent_reference = await repo.get_opint_reference_by_declaration_id(uuid.UUID(operation_id))
 
             if not flight_operational_intent_reference:
                 logger.error("Flight operational intent reference not found in the database")
                 return None
 
-            flight_operational_intent_details = await fd_repo.get_opint_detail_by_declaration_id(uuid.UUID(operation_id))
-            operational_intent_subscribers = await fd_repo.get_subscribers_of_opint_reference(ref_id=flight_operational_intent_reference.id)
+            flight_operational_intent_details = await repo.get_opint_detail_by_declaration_id(uuid.UUID(operation_id))
+            operational_intent_subscribers = await repo.get_subscribers_of_opint_reference(ref_id=flight_operational_intent_reference.id)
 
         subscribers: list[SubscriberToNotify] = []
         for s in operational_intent_subscribers:
@@ -222,19 +233,23 @@ class OperationalIntentReferenceHelper:
         )
         return stored
 
-    async def parse_and_load_stored_flight_operational_intent_reference(self, operation_id: str) -> OperationalIntentDetailsUSSResponse:
+    async def parse_and_load_stored_flight_operational_intent_reference(
+        self, operation_id: str, fd_repo: "SQLAlchemyFlightDeclarationRepository | None" = None
+    ) -> OperationalIntentDetailsUSSResponse:
         """
         Given a stored flight operational intent, get the details of the operational intent
         """
 
-        async with async_task_session() as db:
-            fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-            flight_operational_intent_reference = await fd_repo.get_opint_reference_by_declaration_id(uuid.UUID(operation_id))
+        repo = fd_repo or self.fd_repo
+        if not repo:
+            raise ValueError("fd_repo must be provided either in __init__ or as method parameter")
 
-            if not flight_operational_intent_reference:
-                logger.error("Flight operational intent reference not found in the database")
-                return None
-            flight_operational_intent_details = await fd_repo.get_opint_detail_by_declaration_id(uuid.UUID(operation_id))
+        flight_operational_intent_reference = await repo.get_opint_reference_by_declaration_id(uuid.UUID(operation_id))
+
+        if not flight_operational_intent_reference:
+            logger.error("Flight operational intent reference not found in the database")
+            return None
+        flight_operational_intent_details = await repo.get_opint_detail_by_declaration_id(uuid.UUID(operation_id))
         # Load existing opint details
 
         stored_operational_intent_id = flight_operational_intent_reference.id
@@ -376,10 +391,16 @@ class OperationalIntentReferenceHelper:
 
 
 class SCDOperations:
-    def __init__(self):
+    def __init__(
+        self,
+        fd_repo: "SQLAlchemyFlightDeclarationRepository | None" = None,
+        constraint_repo: "SQLAlchemyConstraintRepository | None" = None,
+    ):
         self.dss_base_url = settings.DSS_BASE_URL
         self.r = get_redis()
         self.constraints_helper = ConstraintOperations()
+        self.fd_repo = fd_repo
+        self.constraint_repo = constraint_repo
 
     async def get_nearby_operational_intents(self, volumes: list[Volume4D]) -> list[OperationalIntentDetailsUSSResponse]:
         # This method checks the USS network for any other volume in the airspace and queries the individual USS for data
@@ -478,40 +499,42 @@ class SCDOperations:
         Falls back to a minimal reference (built from the DSS data, with empty details) when the intent is
         not yet stored, so its OVN is still included in airspace keys (prevents DSS 409 errors).
         """
-        async with async_task_session() as db:
-            fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-            flight_operational_intent_reference = await fd_repo.get_opint_reference_by_id(uuid.UUID(str(dss_reference.id)))
+        repo = self.fd_repo
+        if not repo:
+            raise ValueError("fd_repo must be provided in __init__")
 
-            if flight_operational_intent_reference is not None:
-                flight_declaration_id = flight_operational_intent_reference.declaration_id
-                flight_operational_intent_detail = await fd_repo.get_opint_detail_by_declaration_id(flight_declaration_id)
-                await fd_repo.update_opint_reference_ovn(ref_id=flight_operational_intent_reference.id, ovn=dss_reference.ovn)
-                _op_int_ref = OperationalIntentReferenceDSSResponse(
-                    subscription_id=dss_reference.subscription_id,
-                    id=str(flight_operational_intent_reference.id),
-                    uss_base_url=flight_operational_intent_reference.uss_base_url,
-                    manager=flight_operational_intent_reference.manager,
-                    uss_availability=flight_operational_intent_reference.uss_availability,
-                    version=flight_operational_intent_reference.version,
-                    state=flight_operational_intent_reference.state,
-                    ovn=flight_operational_intent_reference.ovn,
-                    time_start=Time(format="RFC3339", value=flight_operational_intent_reference.time_start),
-                    time_end=Time(format="RFC3339", value=flight_operational_intent_reference.time_end),
+        flight_operational_intent_reference = await repo.get_opint_reference_by_id(uuid.UUID(str(dss_reference.id)))
+
+        if flight_operational_intent_reference is not None:
+            flight_declaration_id = flight_operational_intent_reference.declaration_id
+            flight_operational_intent_detail = await repo.get_opint_detail_by_declaration_id(flight_declaration_id)
+            await repo.update_opint_reference_ovn(ref_id=flight_operational_intent_reference.id, ovn=dss_reference.ovn)
+            _op_int_ref = OperationalIntentReferenceDSSResponse(
+                subscription_id=dss_reference.subscription_id,
+                id=str(flight_operational_intent_reference.id),
+                uss_base_url=flight_operational_intent_reference.uss_base_url,
+                manager=flight_operational_intent_reference.manager,
+                uss_availability=flight_operational_intent_reference.uss_availability,
+                version=flight_operational_intent_reference.version,
+                state=flight_operational_intent_reference.state,
+                ovn=flight_operational_intent_reference.ovn,
+                time_start=Time(format="RFC3339", value=flight_operational_intent_reference.time_start),
+                time_end=Time(format="RFC3339", value=flight_operational_intent_reference.time_end),
+            )
+            op_int_ref = asdict(_op_int_ref)
+            op_int_det = {
+                "volumes": json.loads(flight_operational_intent_detail.volumes),
+                "off_nominal_volumes": json.loads(flight_operational_intent_detail.off_nominal_volumes),
+                "priority": flight_operational_intent_detail.priority,
+            }
+        else:
+            logger.warning(
+                "Flight operational intent reference not found in the database, this is a new operational intent with id: {uss_op_int_id}".format(
+                    uss_op_int_id=dss_reference.id
                 )
-                op_int_ref = asdict(_op_int_ref)
-                op_int_det = {
-                    "volumes": json.loads(flight_operational_intent_detail.volumes),
-                    "off_nominal_volumes": json.loads(flight_operational_intent_detail.off_nominal_volumes),
-                    "priority": flight_operational_intent_detail.priority,
-                }
-            else:
-                logger.warning(
-                    "Flight operational intent reference not found in the database, this is a new operational intent with id: {uss_op_int_id}".format(
-                        uss_op_int_id=dss_reference.id
-                    )
-                )
-                op_int_ref = asdict(dss_reference)
-                op_int_det = {"volumes": [], "off_nominal_volumes": [], "priority": 0}
+            )
+            op_int_ref = asdict(dss_reference)
+            op_int_det = {"volumes": [], "off_nominal_volumes": [], "priority": 0}
         return True, op_int_ref, op_int_det
 
     def _build_uss_operational_intent_detail(self, op_int_ref: dict, op_int_det: dict) -> OperationalIntentDetailsUSSResponse:
@@ -1372,21 +1395,23 @@ class SCDOperations:
 
 
 class DSSAreaClearHandler:
-    def __init__(self, request_id):
+    def __init__(self, request_id, fd_repo: "SQLAlchemyFlightDeclarationRepository | None" = None):
         self.request_id = request_id
+        self.fd_repo = fd_repo
 
     async def clear_area_request(self, extent_raw):
-        my_scd_dss_helper = SCDOperations()
-        my_operational_intent_parser = OperationalIntentReferenceHelper()
+        my_scd_dss_helper = SCDOperations(fd_repo=self.fd_repo)
+        my_operational_intent_parser = OperationalIntentReferenceHelper(fd_repo=self.fd_repo)
         volume4D = my_operational_intent_parser.parse_volume_to_volume4D(volume=extent_raw)
         my_geo_json_converter = VolumesConverter()
         my_geo_json_converter.convert_volumes_to_geojson(volumes=[volume4D])
         view_rect_bounds = my_geo_json_converter.get_bounds()
-        async with async_task_session() as db:
-            fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-            my_rtree_helper = rtree_helper.OperationalIntentsIndexFactory(index_name=OPINT_INDEX_BASEPATH, fd_repo=fd_repo)
-            await my_rtree_helper.generate_active_flights_operational_intents_index()
-            op_ints_exist = await my_rtree_helper.check_op_ints_exist()
+        repo = self.fd_repo
+        if not repo:
+            raise ValueError("fd_repo must be provided")
+        my_rtree_helper = rtree_helper.OperationalIntentsIndexFactory(index_name=OPINT_INDEX_BASEPATH, fd_repo=repo)
+        await my_rtree_helper.generate_active_flights_operational_intents_index()
+        op_ints_exist = await my_rtree_helper.check_op_ints_exist()
         all_existing_op_ints_in_area = []
         if op_ints_exist:
             all_existing_op_ints_in_area = my_rtree_helper.check_box_intersection(view_box=view_rect_bounds)
@@ -1447,19 +1472,24 @@ class DSSAreaClearHandler:
 class DSSOperationalIntentsCreator:
     """Helper to submit an operational intent to the DSS based on an operation ID."""
 
-    def __init__(self, flight_declaration_id: uuid.UUID):
-        # Inline import: flight_declarations_svc imports this module, so a top-level import would be circular.
-        from flight_blender.services.flight_declarations_svc import OperationalIntentsConverter  # noqa: PLC0415
-
+    def __init__(
+        self,
+        flight_declaration_id: uuid.UUID,
+        fd_repo: "SQLAlchemyFlightDeclarationRepository | None" = None,
+        constraint_repo: "SQLAlchemyConstraintRepository | None" = None,
+        operational_intents_converter: Any = None,
+    ):
         self.flight_declaration_id = flight_declaration_id
-        self.my_scd_dss_helper = SCDOperations()
-        self.my_operational_intent_reference_helper = OperationalIntentsConverter()
+        self.my_scd_dss_helper = SCDOperations(fd_repo=fd_repo, constraint_repo=constraint_repo)
+        self.fd_repo = fd_repo
+        self.constraint_repo = constraint_repo
+        self.my_operational_intent_reference_helper = operational_intents_converter
 
     async def validate_flight_declaration_start_end_time(self) -> bool:
-
-        async with async_task_session() as db:
-            fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-            flight_declaration = await fd_repo.get_by_id(self.flight_declaration_id)
+        repo = self.fd_repo
+        if not repo:
+            raise ValueError("fd_repo must be provided")
+        flight_declaration = await repo.get_by_id(self.flight_declaration_id)
         if not flight_declaration:
             return False
         now = arrow.now()
@@ -1472,10 +1502,10 @@ class DSSOperationalIntentsCreator:
 
     async def submit_flight_declaration_to_dss(self):
         fd_id = self.flight_declaration_id
-
-        async with async_task_session() as db:
-            fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-            flight_declaration = await fd_repo.get_by_id(fd_id)
+        repo = self.fd_repo
+        if not repo:
+            raise ValueError("fd_repo must be provided")
+        flight_declaration = await repo.get_by_id(fd_id)
         if not flight_declaration:
             logger.error("Flight Declaration with ID %s not found in the database" % self.flight_declaration_id)
             raise HTTPException(
@@ -1514,55 +1544,52 @@ class DSSOperationalIntentsCreator:
                     off_nominal_volumes=operational_intent_data.off_nominal_volumes,
                     priority=operational_intent_data.priority,
                 )
-                async with async_task_session() as db:
-                    fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-                    created_flight_operational_intent_reference = await fd_repo.create_opint_reference(
+                created_flight_operational_intent_reference = await repo.create_opint_reference(
+                    declaration_id=fd_id,
+                    payload=op_int_submission_result.dss_response.operational_intent_reference,
+                )
+                created_flight_operational_intent_detail = await repo.create_opint_detail(
+                    declaration_id=fd_id,
+                    payload=operational_intent_details_payload,
+                )
+                if created_flight_operational_intent_detail and created_flight_operational_intent_reference:
+                    generated_composite_operational_intent_data = (
+                        self.my_operational_intent_reference_helper.generate_bounds_altitude_time_for_volumes(
+                            operational_intent_details_payload=operational_intent_details_payload,
+                            flight_declaration_id=str(self.flight_declaration_id),
+                        )
+                    )
+                    composite_operational_intent_data = CompositeOperationalIntentPayload(
+                        bounds=generated_composite_operational_intent_data.bounds,
+                        start_datetime=generated_composite_operational_intent_data.start_datetime,
+                        end_datetime=generated_composite_operational_intent_data.end_datetime,
+                        alt_max=generated_composite_operational_intent_data.alt_max,
+                        alt_min=generated_composite_operational_intent_data.alt_min,
+                        operational_intent_reference_id=str(created_flight_operational_intent_reference.id),
+                        operational_intent_details_id=str(created_flight_operational_intent_detail.id),
+                    )
+                    await repo.create_or_update_composite_opint(
                         declaration_id=fd_id,
-                        payload=op_int_submission_result.dss_response.operational_intent_reference,
+                        payload=composite_operational_intent_data,
                     )
-                    created_flight_operational_intent_detail = await fd_repo.create_opint_detail(
-                        declaration_id=fd_id,
-                        payload=operational_intent_details_payload,
-                    )
-                    if created_flight_operational_intent_detail and created_flight_operational_intent_reference:
-                        generated_composite_operational_intent_data = (
-                            self.my_operational_intent_reference_helper.generate_bounds_altitude_time_for_volumes(
-                                operational_intent_details_payload=operational_intent_details_payload,
-                                flight_declaration_id=str(self.flight_declaration_id),
-                            )
-                        )
-                        composite_operational_intent_data = CompositeOperationalIntentPayload(
-                            bounds=generated_composite_operational_intent_data.bounds,
-                            start_datetime=generated_composite_operational_intent_data.start_datetime,
-                            end_datetime=generated_composite_operational_intent_data.end_datetime,
-                            alt_max=generated_composite_operational_intent_data.alt_max,
-                            alt_min=generated_composite_operational_intent_data.alt_min,
-                            operational_intent_reference_id=str(created_flight_operational_intent_reference.id),
-                            operational_intent_details_id=str(created_flight_operational_intent_detail.id),
-                        )
-                        await fd_repo.create_or_update_composite_opint(
-                            declaration_id=fd_id,
-                            payload=composite_operational_intent_data,
-                        )
-                    logger.info("Updating state from Processing to Accepted...")
-                    await fd_repo.update(fd_id, state=OperationStateCode.Accepted)
-                    await fd_repo.add_state_history_entry(
-                        flight_declaration_id=fd_id,
-                        original_state=current_state,
-                        new_state=OperationStateCode.Accepted,
-                        notes="Operational Intent successfully submitted to DSS and is Accepted",
-                    )
+                logger.info("Updating state from Processing to Accepted...")
+                await repo.update(fd_id, state=OperationStateCode.Accepted)
+                await repo.add_state_history_entry(
+                    flight_declaration_id=fd_id,
+                    original_state=current_state,
+                    new_state=OperationStateCode.Accepted,
+                    notes="Operational Intent successfully submitted to DSS and is Accepted",
+                )
                 if op_int_submission_result.constraints:
-                    # Inline import: scd_svc imports this module, so a top-level import would be circular.
+                    if self.constraint_repo is None:
+                        raise ValueError("constraint_repo must be provided when constraints are present")
                     from flight_blender.services.scd_svc import ConstraintsWriter  # noqa: PLC0415
 
-                    async with async_task_session() as db:
-                        constraint_repo = SQLAlchemyConstraintRepository(db)
-                        my_constraints_writer = ConstraintsWriter(constraint_repo=constraint_repo)
-                        await my_constraints_writer.write_nearby_constraints(
-                            flight_declaration=flight_declaration,
-                            constraints=op_int_submission_result.constraints,
-                        )
+                    my_constraints_writer = ConstraintsWriter(constraint_repo=self.constraint_repo)
+                    await my_constraints_writer.write_nearby_constraints(
+                        flight_declaration=flight_declaration,
+                        constraints=op_int_submission_result.constraints,
+                    )
             elif op_int_submission_result.status_code in _DSS_SUBMISSION_REJECTION_CODES:
                 notes = _DSS_SUBMISSION_REJECTION_NOTES.get(op_int_submission_result.status_code, "Unknown error during submission")
                 logger.info(
@@ -1570,26 +1597,22 @@ class DSSOperationalIntentsCreator:
                         status_code=op_int_submission_result.status_code
                     )
                 )
-                async with async_task_session() as db:
-                    fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-                    await fd_repo.update(fd_id, state=OperationStateCode.Rejected)
-                    await fd_repo.add_state_history_entry(
-                        flight_declaration_id=fd_id,
-                        original_state=current_state,
-                        new_state=OperationStateCode.Rejected,
-                        notes=notes,
-                    )
+                await repo.update(fd_id, state=OperationStateCode.Rejected)
+                await repo.add_state_history_entry(
+                    flight_declaration_id=fd_id,
+                    original_state=current_state,
+                    new_state=OperationStateCode.Rejected,
+                    notes=notes,
+                )
             elif op_int_submission_result.status_code == 500 and op_int_submission_result.message == SubmissionResultStatus.ConflictWithFlight.value:
                 logger.info("Flight is not deconflicted, updating state from Processing to Rejected ..")
-                async with async_task_session() as db:
-                    fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-                    await fd_repo.update(fd_id, state=OperationStateCode.Rejected)
-                    await fd_repo.add_state_history_entry(
-                        flight_declaration_id=fd_id,
-                        original_state=current_state,
-                        new_state=OperationStateCode.Rejected,
-                        notes="Flight was not deconflicted correctly",
-                    )
+                await repo.update(fd_id, state=OperationStateCode.Rejected)
+                await repo.add_state_history_entry(
+                    flight_declaration_id=fd_id,
+                    original_state=current_state,
+                    new_state=OperationStateCode.Rejected,
+                    notes="Flight was not deconflicted correctly",
+                )
 
         return op_int_submission_result
 
@@ -1621,7 +1644,7 @@ class DSSOperationalIntentsCreator:
 class SCDTestHarnessHelper:
     """Used in the SCD Test harness to include transformations."""
 
-    def __init__(self, fd_repo: SQLAlchemyFlightDeclarationRepository):
+    def __init__(self, fd_repo: "SQLAlchemyFlightDeclarationRepository"):
         self.my_operational_intent_helper = OperationalIntentReferenceHelper()
         self.r = get_redis()
         self.my_volumes_converter = VolumesConverter()

--- a/src/flight_blender/services/flight_declarations_svc.py
+++ b/src/flight_blender/services/flight_declarations_svc.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from dataclasses import asdict
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import arrow
 import geojson
@@ -44,7 +44,9 @@ from flight_blender.domain_types.scd import (
 from flight_blender.domain_types.scd import Polygon as Plgn
 from flight_blender.plugins.loader import load_plugin
 from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
-from flight_blender.tasks.flight_declarations_task import CelerySCDNotifier
+
+if TYPE_CHECKING:
+    from flight_blender.tasks.flight_declarations_task import CelerySCDNotifier
 
 FLIGHT_BLENDER_PLUGIN_VOLUME_4D_GENERATOR = settings.FLIGHT_BLENDER_PLUGIN_VOLUME_4D_GENERATOR
 
@@ -476,7 +478,7 @@ class FlightDeclarationOperations:
         repo: SQLAlchemyFlightDeclarationRepository,
         scd_client: SCDOperations,
         parser: OperationalIntentReferenceHelper,
-        notifier: CelerySCDNotifier,
+        notifier: "CelerySCDNotifier",
     ):
         self.repo = repo
         self.scd_client = scd_client
@@ -1068,3 +1070,78 @@ class CustomVolumeGenerator:
             time_start=Time(format="RFC3339", value=time_start),
             time_end=Time(format="RFC3339", value=time_end),
         )
+
+
+# ── Task helper functions ────────────────────────────────────────────────
+
+
+async def submit_flight_declaration_to_dss(flight_declaration_id: str):
+    """Submit a flight declaration to the DSS."""
+    from flight_blender.clients.dss_scd_client import DSSOperationalIntentsCreator
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
+
+    async with async_task_session() as db:
+        fd_repo = SQLAlchemyFlightDeclarationRepository(db)
+        my_dss_opint_creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.UUID(flight_declaration_id),
+            fd_repo=fd_repo,
+        )
+        return await my_dss_opint_creator.submit_flight_declaration_to_dss()
+
+
+async def get_flight_declaration(flight_declaration_id: str):
+    """Get a flight declaration from the database."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
+
+    async with async_task_session() as db:
+        fd_repo = SQLAlchemyFlightDeclarationRepository(db)
+        return await fd_repo.get_by_id(uuid.UUID(flight_declaration_id))
+
+
+async def get_opint_reference(flight_declaration_id: str):
+    """Get the operational intent reference for a flight declaration."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
+
+    async with async_task_session() as db:
+        fd_repo = SQLAlchemyFlightDeclarationRepository(db)
+        return await fd_repo.get_opint_reference_by_declaration_id(uuid.UUID(flight_declaration_id))
+
+
+async def verify_and_update_declaration_state(flight_declaration_id: str) -> tuple:
+    """Verify state transition and update to Accepted if valid. Returns (flight_declaration, created_opint)."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
+
+    from flight_blender.services.conformance_svc import FlightOperationConformanceHelper
+
+    async with async_task_session() as db:
+        fd_repo = SQLAlchemyFlightDeclarationRepository(db)
+        flight_declaration = await fd_repo.get_by_id(uuid.UUID(flight_declaration_id))
+
+        if not flight_declaration:
+            return None, None
+
+        opint_ref = await fd_repo.get_opint_reference_by_declaration_id(flight_declaration.id)
+        created_opint = opint_ref.id if opint_ref else None
+
+        original_state = flight_declaration.state
+        accepted_state = OPERATION_STATES[1][0]
+
+        transition_valid = FlightOperationConformanceHelper.verify_operation_state_transition(
+            original_state=original_state,
+            new_state=accepted_state,
+            event="dss_accepts",
+        )
+        if transition_valid:
+            await fd_repo.update(flight_declaration.id, state=accepted_state)
+            await fd_repo.add_state_history_entry(
+                flight_declaration_id=flight_declaration.id,
+                new_state=accepted_state,
+                original_state=original_state,
+                notes="Successfully submitted to the DSS..",
+            )
+
+        return flight_declaration, created_opint

--- a/src/flight_blender/services/flight_feed_svc.py
+++ b/src/flight_blender/services/flight_feed_svc.py
@@ -4,7 +4,7 @@ import uuid
 from dataclasses import asdict
 from enum import Enum
 from itertools import zip_longest
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import arrow
 import dacite
@@ -31,7 +31,9 @@ from flight_blender.domain_types.rid import (
     SubmittedTelemetryFlightDetails,
 )
 from flight_blender.repositories.flight_feed_repo import SQLAlchemyFlightFeedRepository
-from flight_blender.tasks.flight_feed_task import CeleryFlightFeedTaskDispatcher
+
+if TYPE_CHECKING:
+    from flight_blender.tasks.flight_feed_task import CeleryFlightFeedTaskDispatcher
 
 
 def _check_view_port(view_port_coords: list[float]) -> bool:
@@ -56,7 +58,7 @@ class FlightFeedOperations:
     def __init__(
         self,
         repo: SQLAlchemyFlightFeedRepository,
-        dispatcher: CeleryFlightFeedTaskDispatcher,
+        dispatcher: "CeleryFlightFeedTaskDispatcher",
         telemetry_validator: "FlightBlenderTelemetryValidator",
         redis: Any,
     ):
@@ -505,3 +507,40 @@ class ObservationReadOperations:
             else:
                 pending_messages.append(observation)
         return pending_messages
+
+
+# ── Task helper functions ────────────────────────────────────────────────
+
+
+async def bulk_write_flight_observations(observations: list) -> None:
+    """Write multiple flight observations to the database in bulk."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.flight_feed_repo import SQLAlchemyFlightFeedRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemyFlightFeedRepository(db)
+        await repo.bulk_write_flight_observations(observations)
+
+
+async def write_flight_observation(observation) -> None:
+    """Write a single flight observation to the database."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.flight_feed_repo import SQLAlchemyFlightFeedRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemyFlightFeedRepository(db)
+        await repo.write_flight_observation(observation)
+
+
+async def get_latest_flight_observation_by_declaration_id(flight_declaration_id: str):
+    """Get the latest flight observation for a declaration."""
+    from flight_blender.auth.token_cache import get_redis
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.flight_feed_repo import SQLAlchemyFlightFeedRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemyFlightFeedRepository(db)
+        obs_helper = ObservationReadOperations(repo=repo, redis=get_redis())
+        return await obs_helper.get_latest_flight_observation_by_flight_declaration_id(
+            flight_declaration_id=flight_declaration_id
+        )

--- a/src/flight_blender/services/geo_fence_svc.py
+++ b/src/flight_blender/services/geo_fence_svc.py
@@ -320,3 +320,35 @@ def validate_geo_zone(geo_zone) -> bool:
     all_zones = parse_response.all_zones
     all_zones_valid = all(all_zones)
     return all_zones_valid
+
+
+async def save_geofence_feature(
+    geo_zone_feature,
+    fc: dict,
+    bounds_str: str,
+    name: str,
+    start_time,
+    end_time,
+    upper_limit,
+    lower_limit,
+    test_harness_datasource: int,
+) -> None:
+    """Save a single geofence feature to the database."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.models.geo_fence_orm import GeoFenceORM
+
+    async with async_task_session() as db:
+        db.add(
+            GeoFenceORM(
+                geozone=json.dumps(geo_zone_feature),
+                raw_geo_fence=json.dumps(fc),
+                start_datetime=start_time,
+                end_datetime=end_time,
+                upper_limit=upper_limit,
+                lower_limit=lower_limit,
+                bounds=bounds_str,
+                name=name,
+                is_test_dataset=bool(test_harness_datasource),
+            )
+        )
+        await db.flush()

--- a/src/flight_blender/services/rid_svc.py
+++ b/src/flight_blender/services/rid_svc.py
@@ -349,3 +349,82 @@ class USSPollingService:
             else:
                 logger.info("Received a non 200 error from {url} : {status_code} ".format(url=rid_query_url, status_code=flights_request.status_code))
                 logger.info("Detailed Response %s" % flights_request.text)
+
+
+# ── Task helper functions ────────────────────────────────────────────────
+
+
+async def create_rid_notification(message: str, session_id):
+    """Create a notification for RID operations."""
+    import uuid as uuid_mod
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.notifications_repo import SQLAlchemyNotificationsRepository
+
+    try:
+        session_uuid = uuid_mod.UUID(session_id)
+    except (ValueError, AttributeError):
+        session_uuid = None
+    async with async_task_session() as db:
+        repo = SQLAlchemyNotificationsRepository(db)
+        await repo.create_notification(message=message, session_id=session_uuid)
+
+
+async def create_rid_subscription(subscription_id, record_id, view_hash, end_datetime, is_simulated, view, flights_dict):
+    """Create a RID subscription."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.rid_repo import SQLAlchemyRIDRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemyRIDRepository(db)
+        await repo.create_subscription(
+            subscription_id=subscription_id,
+            record_id=record_id,
+            view_hash=view_hash,
+            end_datetime=end_datetime,
+            is_simulated=is_simulated,
+            view=view,
+            flights_dict=flights_dict,
+        )
+
+
+async def create_or_update_rid_flight_detail(rid_flight_details_payload):
+    """Create or update RID flight details."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.rid_repo import SQLAlchemyRIDRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemyRIDRepository(db)
+        await repo.create_or_update_flight_detail(rid_flight_details_payload=rid_flight_details_payload)
+
+
+async def update_telemetry_timestamp(operation_id):
+    """Update telemetry timestamp for an operation."""
+    import uuid as uuid_mod
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemyFlightDeclarationRepository(db)
+        await repo.update_telemetry_timestamp(uuid_mod.UUID(operation_id))
+
+
+async def get_rid_subscription(subscription_id):
+    """Get a RID subscription."""
+    import uuid as uuid_mod
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.rid_repo import SQLAlchemyRIDRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemyRIDRepository(db)
+        return await repo.get_subscription_by_id(uuid_mod.UUID(subscription_id))
+
+
+async def create_rid_observations(observations):
+    """Write RID observations to the database."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.flight_feed_repo import SQLAlchemyFlightFeedRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemyFlightFeedRepository(db)
+        for obs in observations:
+            await repo.write_flight_observation(single_observation=obs)

--- a/src/flight_blender/services/scd_svc.py
+++ b/src/flight_blender/services/scd_svc.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 from flight_blender.clients import dss_scd_client as dss_scd_helper
 from flight_blender.clients.dss_scd_client import DSSAreaClearHandler, SCDTestHarnessHelper
+from flight_blender.db.session import async_task_session
 from flight_blender.domain_types.common import ALTITUDE_REF_LOOKUP, OPERATION_STATES, OPERATION_STATES_LOOKUP, OperationStateCode
 from flight_blender.domain_types.constraint import CompositeConstraintPayload, Constraint
 from flight_blender.domain_types.geo_fence import GeofencePayload
@@ -438,7 +439,9 @@ async def clear_area(request: ClearAreaRequestSchema) -> ClearAreaResponseSchema
     if request.request_id is None or request.extent is None:
         raise HTTPException(status_code=400, detail={"result": "Clear area payload must contain 'request_id' and 'extent'"})
     extent_raw = request.extent.model_dump(mode="json", exclude_none=True)
-    handler = DSSAreaClearHandler(request_id=request.request_id)
+    async with async_task_session() as db:
+        fd_repo = SQLAlchemyFlightDeclarationRepository(db)
+        handler = DSSAreaClearHandler(request_id=request.request_id, fd_repo=fd_repo)
     clear_area_response = await handler.clear_area_request(extent_raw=extent_raw)
     return ClearAreaResponseSchema.model_validate(clear_area_response)
 

--- a/src/flight_blender/services/surveillance_svc.py
+++ b/src/flight_blender/services/surveillance_svc.py
@@ -849,3 +849,58 @@ class TrafficDataFuser(BaseTrafficDataFuser):
                     observations=[asdict(obs) for obs in observations],
                 )
                 track_store.add_active_track_to_session(session_id=self.session_id, active_track=active_track)
+
+
+# ── Task helper functions ────────────────────────────────────────────────
+
+
+async def record_surveillance_track_event(session_id: uuid.UUID, expected_at, had_active_tracks: bool) -> None:
+    """Record a track event for a surveillance session."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.surveillance_repo import SQLAlchemySurveillanceRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemySurveillanceRepository(db)
+        await repo.record_track_event(
+            session_id=session_id,
+            expected_at=expected_at,
+            had_active_tracks=had_active_tracks,
+        )
+
+
+async def get_surveillance_sensor_health() -> tuple[float, int]:
+    """Get average latency and horizontal accuracy from active sensors."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.surveillance_repo import SQLAlchemySurveillanceRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemySurveillanceRepository(db)
+        active_sensors = await repo.get_active_surveillance_sensors()
+        if active_sensors:
+            primary_sensor = active_sensors[0]
+            return primary_sensor.expected_latency_ms, int(primary_sensor.horizontal_accuracy_m)
+    return 0, 0
+
+
+async def record_surveillance_heartbeat_event(session_id: uuid.UUID, expected_at, delivered_on_time: bool) -> None:
+    """Record a heartbeat event for a surveillance session."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.surveillance_repo import SQLAlchemySurveillanceRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemySurveillanceRepository(db)
+        await repo.record_heartbeat_event(
+            session_id=session_id,
+            expected_at=expected_at,
+            delivered_on_time=delivered_on_time,
+        )
+
+
+async def cleanup_old_surveillance_events(cutoff) -> tuple[int, int]:
+    """Delete old surveillance events."""
+    from flight_blender.db.session import async_task_session
+    from flight_blender.repositories.surveillance_repo import SQLAlchemySurveillanceRepository
+
+    async with async_task_session() as db:
+        repo = SQLAlchemySurveillanceRepository(db)
+        return await repo.cleanup_old_events(cutoff=cutoff)

--- a/src/flight_blender/tasks/conformance_task.py
+++ b/src/flight_blender/tasks/conformance_task.py
@@ -3,14 +3,12 @@ import uuid
 
 from loguru import logger
 
-from flight_blender.auth.token_cache import get_redis
 from flight_blender.celery import app
 from flight_blender.db.session import async_task_session
 from flight_blender.domain_types.scd import LatLngPoint
-from flight_blender.repositories.flight_feed_repo import SQLAlchemyFlightFeedRepository
 from flight_blender.services import conformance_svc as custom_signals
-from flight_blender.services import flight_feed_svc as flight_stream_helper
 from flight_blender.services.conformance_svc import FlightBlenderConformanceEngine
+from flight_blender.services.flight_feed_svc import get_latest_flight_observation_by_declaration_id
 
 
 # This method conducts flight conformance checks as a async tasks
@@ -56,10 +54,7 @@ async def _async_check_operation_telemetry_conformance(flight_declaration_id: st
     # This method checks the conformance status for ongoing operations and sends notifications / via the notifications channel
     dry_run = dry_run == "1"
     # Get Telemetry
-    async with async_task_session() as db:
-        feed_repo = SQLAlchemyFlightFeedRepository(db)
-        obs_helper = flight_stream_helper.ObservationReadOperations(repo=feed_repo, redis=get_redis())
-        latest_rid_observation = await obs_helper.get_latest_flight_observation_by_flight_declaration_id(flight_declaration_id=flight_declaration_id)
+    latest_rid_observation = await get_latest_flight_observation_by_declaration_id(flight_declaration_id)
     # Get the latest telemetry
 
     if not latest_rid_observation:

--- a/src/flight_blender/tasks/flight_declarations_task.py
+++ b/src/flight_blender/tasks/flight_declarations_task.py
@@ -1,20 +1,17 @@
 import asyncio
 import json
-import uuid
 
 import arrow
 from dacite import from_dict
 from loguru import logger
 
 from flight_blender.celery import app
-from flight_blender.clients.dss_scd_client import DSSOperationalIntentsCreator
+from flight_blender.clients.dss_scd_client import SCDOperations
 from flight_blender.clients.notification_client import NotificationFactory
 from flight_blender.config import settings
-from flight_blender.db.session import async_task_session
-from flight_blender.domain_types.common import OPERATION_STATES
 from flight_blender.domain_types.notifications import FlightDeclarationUpdateMessage
 from flight_blender.domain_types.scd import NotifyPeerUSSPostPayload, OperationalIntentDetailsUSSResponse, OperationalIntentUSSDetails
-from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
+from flight_blender.services.flight_declarations_svc import submit_flight_declaration_to_dss, verify_and_update_declaration_state
 
 
 @app.task(name="submit_flight_declaration_to_dss_async")
@@ -23,39 +20,7 @@ def submit_flight_declaration_to_dss_async(flight_declaration_id: str):
 
 
 async def _async_submit_flight_declaration_to_dss(flight_declaration_id: str) -> None:
-    my_dss_opint_creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.UUID(flight_declaration_id))
-
-    start_end_time_validated = await my_dss_opint_creator.validate_flight_declaration_start_end_time()
-
-    logger.info("Flight Operation start end time status %s" % start_end_time_validated)
-
-    if not start_end_time_validated:
-        logger.error(
-            "Flight Declaration start / end times are not valid, please check the submitted declaration, this operation will not be sent to the DSS for strategic deconfliction"
-        )
-        validation_not_ok_msg = (
-            "Flight Operation with ID {operation_id} did not pass time validation, start and end time may not be ahead of two hours".format(
-                operation_id=flight_declaration_id
-            )
-        )
-        send_operational_update_message.delay(
-            flight_declaration_id=flight_declaration_id,
-            message_text=validation_not_ok_msg,
-            level="error",
-        )
-        return
-
-    validation_ok_msg = "Flight Operation with ID {operation_id} validated for start and end time, submitting to DSS..".format(
-        operation_id=flight_declaration_id
-    )
-    send_operational_update_message.delay(
-        flight_declaration_id=flight_declaration_id,
-        message_text=validation_ok_msg,
-        level="info",
-    )
-    logger.info("Submitting flight declaration to DSS..")
-
-    opint_submission_result = await my_dss_opint_creator.submit_flight_declaration_to_dss()
+    opint_submission_result = await submit_flight_declaration_to_dss(flight_declaration_id)
 
     if opint_submission_result.status_code == 500:
         logger.error("Error in submitting Flight Declaration to the DSS %s" % opint_submission_result.status)
@@ -97,36 +62,11 @@ async def _async_submit_flight_declaration_to_dss(flight_declaration_id: str) ->
             level="info",
         )
 
-        async with async_task_session() as db:
-            fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-            flight_declaration = await fd_repo.get_by_id(uuid.UUID(flight_declaration_id))
+        flight_declaration, created_opint = await verify_and_update_declaration_state(flight_declaration_id)
 
-            if not flight_declaration:
-                logger.error("Flight Declaration with ID %s not found in the database" % flight_declaration_id)
-                return
-
-            opint_ref = await fd_repo.get_opint_reference_by_declaration_id(flight_declaration.id)
-            created_opint = opint_ref.id if opint_ref else None
-
-            logger.info("Changing operation state..")
-            original_state = flight_declaration.state
-            accepted_state = OPERATION_STATES[1][0]
-            from flight_blender.services.conformance_svc import FlightOperationConformanceHelper  # noqa: PLC0415
-
-            transition_valid = FlightOperationConformanceHelper.verify_operation_state_transition(
-                original_state=original_state,
-                new_state=accepted_state,
-                event="dss_accepts",
-            )
-            if transition_valid:
-                await fd_repo.update(flight_declaration.id, state=accepted_state)
-                logger.info("The state change transition to Accepted state from current state Created is valid..")
-                await fd_repo.add_state_history_entry(
-                    flight_declaration_id=flight_declaration.id,
-                    new_state=accepted_state,
-                    original_state=original_state,
-                    notes="Successfully submitted to the DSS..",
-                )
+        if not flight_declaration:
+            logger.error("Flight Declaration with ID %s not found in the database" % flight_declaration_id)
+            return
 
         submission_state_updated_msg = "Flight Operation with ID {operation_id} has a updated state: Accepted. ".format(
             operation_id=flight_declaration_id
@@ -160,7 +100,8 @@ async def _async_submit_flight_declaration_to_dss(flight_declaration_id: str) ->
                         operational_intent=operational_intent,
                         subscriptions=subscriptions_raw,
                     )
-                    my_dss_opint_creator.notify_peer_uss(
+                    scd_ops = SCDOperations()
+                    scd_ops.notify_peer_uss(
                         uss_base_url=uss_base_url,
                         notification_payload=post_notification_payload,
                     )

--- a/src/flight_blender/tasks/flight_feed_task.py
+++ b/src/flight_blender/tasks/flight_feed_task.py
@@ -14,9 +14,8 @@ from pyproj import Transformer
 from flight_blender.celery import app
 from flight_blender.clients.redis_client import RedisStreamOperations
 from flight_blender.config import settings
-from flight_blender.db.session import async_task_session
 from flight_blender.domain_types.flight_feed import SingleAirtrafficObservation
-from flight_blender.repositories.flight_feed_repo import SQLAlchemyFlightFeedRepository
+from flight_blender.services.flight_feed_svc import bulk_write_flight_observations, write_flight_observation
 
 #### Airtraffic Endpoint
 
@@ -49,9 +48,7 @@ async def _async_bulk_write_incoming_air_traffic_data(observations_str: str) -> 
 
     if parsed_observations:
         logger.info(f"Writing {len(parsed_observations)} observations to database in bulk..")
-        async with async_task_session() as db:
-            repo = SQLAlchemyFlightFeedRepository(db)
-            await repo.bulk_write_flight_observations(parsed_observations)
+        await bulk_write_flight_observations(parsed_observations)
 
         logger.info("Writing batch to Redis stream..")
         for single_obs in parsed_observations:
@@ -87,9 +84,7 @@ async def _async_write_incoming_air_traffic_data(observation: str) -> None:
     logger.debug(f"Parsed observation: {single_air_traffic_observation}")
 
     logger.info("Writing observation..")
-    async with async_task_session() as db:
-        repo = SQLAlchemyFlightFeedRepository(db)
-        await repo.write_flight_observation(single_air_traffic_observation)
+    await write_flight_observation(single_air_traffic_observation)
 
     logger.info("Writing to Redis stream..")
     my_redis_helper.add_air_traffic_data(stream_name="air_traffic_stream", observation=asdict(single_air_traffic_observation))

--- a/src/flight_blender/tasks/geo_fence_task.py
+++ b/src/flight_blender/tasks/geo_fence_task.py
@@ -11,10 +11,8 @@ from shapely.ops import unary_union
 
 from flight_blender.auth.token_cache import get_redis
 from flight_blender.celery import app
-from flight_blender.db.session import async_task_session
 from flight_blender.domain_types.geo_fence import GeoAwarenessTestStatus
-from flight_blender.models.geo_fence_orm import GeoFenceORM
-from flight_blender.services.geo_fence_svc import GeoZoneParser
+from flight_blender.services.geo_fence_svc import GeoZoneParser, save_geofence_feature
 
 
 @app.task(name="download_geozone_source")
@@ -80,21 +78,17 @@ async def _async_write_geo_zone(geo_zone: str, test_harness_datasource: str = "0
         end_time = start_time.shift(years=1)
         upper_limit = geo_zone_feature["upperLimit"] if "upperLimit" in geo_zone_feature else 300
         lower_limit = geo_zone_feature["lowerLimit"] if "lowerLimit" in geo_zone_feature else 10
-        async with async_task_session() as db:
-            db.add(
-                GeoFenceORM(
-                    geozone=json.dumps(geo_zone_feature),
-                    raw_geo_fence=json.dumps(fc),
-                    start_datetime=start_time.datetime,
-                    end_datetime=end_time.datetime,
-                    upper_limit=upper_limit,
-                    lower_limit=lower_limit,
-                    bounds=bounds_str,
-                    name=name,
-                    is_test_dataset=bool(test_harness_datasource),
-                )
-            )
-            await db.flush()
+        await save_geofence_feature(
+            geo_zone_feature=geo_zone_feature,
+            fc=fc,
+            bounds_str=bounds_str,
+            name=name,
+            start_time=start_time.datetime,
+            end_time=end_time.datetime,
+            upper_limit=upper_limit,
+            lower_limit=lower_limit,
+            test_harness_datasource=test_harness_datasource,
+        )
 
         logger.info("Saved Geofence to database ..")
 

--- a/src/flight_blender/tasks/rid_task.py
+++ b/src/flight_blender/tasks/rid_task.py
@@ -38,12 +38,10 @@ from flight_blender.domain_types.rid_operations import (
     RIDVolume4D,
     SingleObservationMetadata,
 )
-from flight_blender.repositories.flight_declarations_repo import SQLAlchemyFlightDeclarationRepository
 from flight_blender.repositories.flight_feed_repo import SQLAlchemyFlightFeedRepository
-from flight_blender.repositories.notifications_repo import SQLAlchemyNotificationsRepository
 from flight_blender.repositories.rid_repo import SQLAlchemyRIDRepository
 from flight_blender.services.altitude import wgs84_to_barometric
-from flight_blender.services.rid_svc import USSPollingService
+from flight_blender.services.rid_svc import USSPollingService, create_rid_notification, get_rid_subscription, update_telemetry_timestamp
 from flight_blender.tasks.flight_feed_task import write_incoming_air_traffic_data
 
 
@@ -99,13 +97,7 @@ def write_operator_rid_notification(message: str, session_id: str):
 
 
 async def _async_write_operator_rid_notification(message: str, session_id: str) -> None:
-    try:
-        session_uuid = uuid.UUID(session_id)
-    except (ValueError, AttributeError):
-        session_uuid = None
-    async with async_task_session() as db:
-        repo = SQLAlchemyNotificationsRepository(db)
-        await repo.create_notification(message=message, session_id=session_uuid)
+    await create_rid_notification(message=message, session_id=session_id)
 
 
 async def _async_process_requested_flight(
@@ -113,7 +105,7 @@ async def _async_process_requested_flight(
     flight_injection_sorted_set: str,
     test_id: str,
     injection_id: uuid.UUID,
-    rid_repo: SQLAlchemyRIDRepository,
+    rid_repo: "SQLAlchemyRIDRepository",
 ) -> tuple[RIDTestInjection, list[LatLngPoint], list[float]]:
     """
     Processes a requested flight by parsing flight details and telemetry data, storing relevant information in Redis,
@@ -338,10 +330,10 @@ async def _async_run_ussp_polling_for_rid(end_time: str, session_id: str) -> Non
     r = get_redis()
     async_polling_lock = f"async_polling_lock_{session_id}"
 
+    subscription_record = await get_rid_subscription(session_id)
     async with async_task_session() as db:
         rid_repo = SQLAlchemyRIDRepository(db)
         feed_repo = SQLAlchemyFlightFeedRepository(db)
-        subscription_record = await rid_repo.get_subscription_by_id(uuid.UUID(session_id))
         my_dss_subscriber = USSPollingService(rid_repo=rid_repo, feed_repo=feed_repo)
 
         if r.exists(async_polling_lock):
@@ -385,9 +377,7 @@ async def _async_stream_rid_telemetry_data(rid_telemetry_observations) -> None:
         current_states = observation["current_states"]
         operation_id = flight_details["id"]
 
-        async with async_task_session() as db:
-            fd_repo = SQLAlchemyFlightDeclarationRepository(db)
-            await fd_repo.update_telemetry_timestamp(uuid.UUID(operation_id))
+        await update_telemetry_timestamp(operation_id)
 
         for current_state in current_states:
             _current_state = from_dict(data_class=LocalRIDAircraftState, data=current_state, config=Config(cast=[Enum]))
@@ -654,12 +644,6 @@ async def _async_check_rid_stream_conformance(session_id: str) -> None:
         return
 
     logger.info(f"RID Data stream for {session_id} is NOT OK...")
-    try:
-        session_uuid = uuid.UUID(session_id)
-    except (ValueError, AttributeError):
-        session_uuid = None
 
-    async with async_task_session() as db:
-        notif_repo = SQLAlchemyNotificationsRepository(db)
-        for error_msg in errors:
-            await notif_repo.create_notification(message=error_msg, session_id=session_uuid)
+    for error_msg in errors:
+        await create_rid_notification(message=error_msg, session_id=session_id)

--- a/src/flight_blender/tasks/surveillance_task.py
+++ b/src/flight_blender/tasks/surveillance_task.py
@@ -11,11 +11,15 @@ from flight_blender.auth.token_cache import get_redis
 from flight_blender.celery import app
 from flight_blender.clients.redis_client import RedisStreamOperations
 from flight_blender.config import settings
-from flight_blender.db.session import async_task_session
 from flight_blender.domain_types.plugin_protocols import TrafficDataFuserProtocol
 from flight_blender.domain_types.surveillance import HeartbeatMessage
 from flight_blender.plugins.loader import load_plugin
-from flight_blender.repositories.surveillance_repo import SQLAlchemySurveillanceRepository
+from flight_blender.services.surveillance_svc import (
+    cleanup_old_surveillance_events,
+    get_surveillance_sensor_health,
+    record_surveillance_heartbeat_event,
+    record_surveillance_track_event,
+)
 
 BROKER_URL = settings.REDIS_BROKER_URL
 FLIGHT_BLENDER_PLUGIN_TRAFFIC_DATA_FUSER = settings.FLIGHT_BLENDER_PLUGIN_TRAFFIC_DATA_FUSER
@@ -68,13 +72,11 @@ async def _async_send_and_generate_track_to_consumer(
 
     _publish_realtime_message(f"track_{surveillance_session_id}", all_track_data)
 
-    async with async_task_session() as db:
-        repo = SQLAlchemySurveillanceRepository(db)
-        await repo.record_track_event(
-            session_id=uuid.UUID(surveillance_session_id),
-            expected_at=expected_at,
-            had_active_tracks=len(track_messages) > 0,
-        )
+    await record_surveillance_track_event(
+        session_id=uuid.UUID(surveillance_session_id),
+        expected_at=expected_at,
+        had_active_tracks=len(track_messages) > 0,
+    )
 
     send_and_generate_track_to_consumer.apply_async(
         args=[session_id, flight_declaration_id],
@@ -99,16 +101,8 @@ async def _async_send_heartbeat_to_consumer(session_id: str, flight_declaration_
     logger.info(f"Preparing to send heartbeat for surveillance session with id: {surveillance_session_id}")
 
     expected_at = arrow.utcnow().datetime
-    avg_latency_ms = 0
-    h_accuracy_m = 0
 
-    async with async_task_session() as db:
-        repo = SQLAlchemySurveillanceRepository(db)
-        active_sensors = await repo.get_active_surveillance_sensors()
-        if active_sensors:
-            primary_sensor = active_sensors[0]
-            avg_latency_ms = primary_sensor.expected_latency_ms
-            h_accuracy_m = int(primary_sensor.horizontal_accuracy_m)
+    avg_latency_ms, h_accuracy_m = await get_surveillance_sensor_health()
 
     heartbeat_data = HeartbeatMessage(
         surveillance_sdsp_name=surveillance_session_id,
@@ -131,13 +125,11 @@ async def _async_send_heartbeat_to_consumer(session_id: str, flight_declaration_
     latency_secs = abs((dispatch_at - expected_at).total_seconds())
     delivered_on_time = dispatch_succeeded and latency_secs <= _MAX_ACCEPTABLE_LATENCY_SECS
 
-    async with async_task_session() as db:
-        repo = SQLAlchemySurveillanceRepository(db)
-        await repo.record_heartbeat_event(
-            session_id=uuid.UUID(surveillance_session_id),
-            expected_at=expected_at,
-            delivered_on_time=delivered_on_time,
-        )
+    await record_surveillance_heartbeat_event(
+        session_id=uuid.UUID(surveillance_session_id),
+        expected_at=expected_at,
+        delivered_on_time=delivered_on_time,
+    )
 
     send_heartbeat_to_consumer.apply_async(
         args=[session_id, flight_declaration_id],
@@ -161,9 +153,7 @@ async def _async_cleanup_old_heartbeat_events() -> None:
     retention_days = settings.HEARTBEAT_RETENTION_DAYS
     cutoff = arrow.utcnow().shift(days=-retention_days).datetime
 
-    async with async_task_session() as db:
-        repo = SQLAlchemySurveillanceRepository(db)
-        deleted_heartbeats, deleted_tracks = await repo.cleanup_old_events(cutoff=cutoff)
+    deleted_heartbeats, deleted_tracks = await cleanup_old_surveillance_events(cutoff=cutoff)
 
     logger.info(
         f"cleanup_old_heartbeat_events: deleted {deleted_heartbeats} heartbeat events "

--- a/tests/test_conformance_operations.py
+++ b/tests/test_conformance_operations.py
@@ -288,10 +288,7 @@ class TestCheckFlightConformanceTask:
 
 class TestCheckOperationTelemetryConformanceTask:
     def test_no_observation_returns_early(self):
-        with patch("flight_blender.tasks.conformance_task.flight_stream_helper.ObservationReadOperations") as mock_obs_cls:
-            mock_obs_instance = MagicMock()
-            mock_obs_instance.get_latest_flight_observation_by_flight_declaration_id = AsyncMock(return_value=None)
-            mock_obs_cls.return_value = mock_obs_instance
+        with patch("flight_blender.tasks.conformance_task.get_latest_flight_observation_by_declaration_id", new_callable=AsyncMock, return_value=None):
             # Should return early without raising
             check_operation_telemetry_conformance(flight_declaration_id=str(uuid.uuid4()))
 

--- a/tests/test_scd_opint_helper.py
+++ b/tests/test_scd_opint_helper.py
@@ -94,151 +94,168 @@ class TestDSSOperationalIntentsCreatorValidateTime:
     @pytest.mark.asyncio
     async def test_valid_start_end_time(self):
         """Declarations starting within 2 h return True."""
-        creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.uuid4())
+        mock_fd_repo = AsyncMock()
+        creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.uuid4(),
+            fd_repo=mock_fd_repo,
+        )
         fd = _fake_flight_declaration()
         fd.start_datetime = arrow.utcnow().shift(minutes=10).datetime
         fd.end_datetime = arrow.utcnow().shift(minutes=90).datetime
-        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.get_by_id", new_callable=AsyncMock, return_value=fd):
-            assert await creator.validate_flight_declaration_start_end_time() is True
+        mock_fd_repo.get_by_id = AsyncMock(return_value=fd)
+        assert await creator.validate_flight_declaration_start_end_time() is True
 
     @pytest.mark.asyncio
     async def test_past_start_time_returns_false(self):
         """Declarations with start in the past return False."""
-        creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.uuid4())
+        mock_fd_repo = AsyncMock()
+        creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.uuid4(),
+            fd_repo=mock_fd_repo,
+        )
         fd = _fake_flight_declaration()
         fd.start_datetime = arrow.utcnow().shift(hours=-1).datetime
         fd.end_datetime = arrow.utcnow().shift(hours=1).datetime
-        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.get_by_id", new_callable=AsyncMock, return_value=fd):
-            assert await creator.validate_flight_declaration_start_end_time() is False
+        mock_fd_repo.get_by_id = AsyncMock(return_value=fd)
+        assert await creator.validate_flight_declaration_start_end_time() is False
 
     @pytest.mark.asyncio
     async def test_far_future_start_time_returns_false(self):
         """Declarations starting more than 2 h from now return False."""
-        creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.uuid4())
+        mock_fd_repo = AsyncMock()
+        creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.uuid4(),
+            fd_repo=mock_fd_repo,
+        )
         fd = _fake_flight_declaration()
         fd.start_datetime = arrow.utcnow().shift(hours=3).datetime
         fd.end_datetime = arrow.utcnow().shift(hours=4).datetime
-        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.get_by_id", new_callable=AsyncMock, return_value=fd):
-            assert await creator.validate_flight_declaration_start_end_time() is False
+        mock_fd_repo.get_by_id = AsyncMock(return_value=fd)
+        assert await creator.validate_flight_declaration_start_end_time() is False
 
 
 class TestDSSOperationalIntentsCreatorSubmit:
     @pytest.mark.asyncio
     async def test_not_found_returns_declaration_not_found(self):
-        creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.uuid4())
-        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.get_by_id", new_callable=AsyncMock, return_value=None):
-            with pytest.raises(HTTPException) as exc_info:
-                await creator.submit_flight_declaration_to_dss()
+        mock_fd_repo = AsyncMock()
+        mock_fd_repo.get_by_id = AsyncMock(return_value=None)
+        creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.uuid4(),
+            fd_repo=mock_fd_repo,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await creator.submit_flight_declaration_to_dss()
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == {"message": "Flight Declaration with ID %s not found in the database" % creator.flight_declaration_id}
 
     @pytest.mark.asyncio
     async def test_auth_error_returns_auth_server_error(self):
-        creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.uuid4())
+        mock_fd_repo = AsyncMock()
         fd = _fake_flight_declaration()
-        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.get_by_id", new_callable=AsyncMock, return_value=fd):
-            with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"error": "conn_error"}):
-                with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.update", new_callable=AsyncMock):
-                    with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.add_state_history_entry", new_callable=AsyncMock):
-                        with pytest.raises(HTTPException) as exc_info:
-                            await creator.submit_flight_declaration_to_dss()
+        mock_fd_repo.get_by_id = AsyncMock(return_value=fd)
+        creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.uuid4(),
+            fd_repo=mock_fd_repo,
+        )
+        with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"error": "conn_error"}):
+            with pytest.raises(HTTPException) as exc_info:
+                await creator.submit_flight_declaration_to_dss()
         assert exc_info.value.status_code == 500
         assert exc_info.value.detail == {"message": "Error in getting a token from the Auth server"}
 
     @pytest.mark.asyncio
     async def test_successful_submission_updates_state(self):
-        creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.uuid4())
+        mock_fd_repo = AsyncMock()
         fd = _fake_flight_declaration()
         opint_ref = _fake_opint_ref()
         opint_detail = _fake_opint_detail()
+        mock_fd_repo.get_by_id = AsyncMock(return_value=fd)
+        mock_fd_repo.create_opint_reference = AsyncMock(return_value=opint_ref)
+        mock_fd_repo.create_opint_detail = AsyncMock(return_value=opint_detail)
+        mock_fd_repo.create_or_update_composite_opint = AsyncMock()
+        mock_fd_repo.update = AsyncMock()
+        mock_fd_repo.add_state_history_entry = AsyncMock()
+        mock_converter = MagicMock()
+        mock_converter.generate_bounds_altitude_time_for_volumes = MagicMock(
+            return_value=MagicMock(
+                bounds="0,0,1,1",
+                start_datetime=arrow.utcnow().shift(minutes=5).datetime,
+                end_datetime=arrow.utcnow().shift(hours=1).datetime,
+                alt_max=100,
+                alt_min=0,
+            )
+        )
+        creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.uuid4(),
+            fd_repo=mock_fd_repo,
+            operational_intents_converter=mock_converter,
+        )
         success = _submission_success()
-        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.get_by_id", new_callable=AsyncMock, return_value=fd):
-            with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"access_token": "tok"}):
-                with patch.object(creator.my_scd_dss_helper, "create_and_submit_operational_intent_reference", new_callable=AsyncMock, return_value=success):
-                    with patch(
-                        "flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.create_opint_reference",
-                        new_callable=AsyncMock,
-                        return_value=opint_ref,
-                    ):
-                        with patch(
-                            "flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.create_opint_detail",
-                            new_callable=AsyncMock,
-                            return_value=opint_detail,
-                        ):
-                            with patch.object(
-                                creator.my_operational_intent_reference_helper,
-                                "generate_bounds_altitude_time_for_volumes",
-                                return_value=MagicMock(
-                                    bounds="0,0,1,1",
-                                    start_datetime=arrow.utcnow().shift(minutes=5).datetime,
-                                    end_datetime=arrow.utcnow().shift(hours=1).datetime,
-                                    alt_max=100,
-                                    alt_min=0,
-                                ),
-                            ):
-                                with patch(
-                                    "flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.create_or_update_composite_opint",
-                                    new_callable=AsyncMock,
-                                ):
-                                    with patch(
-                                        "flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.update",
-                                        new_callable=AsyncMock,
-                                    ) as mock_state:
-                                        with patch(
-                                            "flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.add_state_history_entry",
-                                            new_callable=AsyncMock,
-                                        ):
-                                            result = await creator.submit_flight_declaration_to_dss()
+        with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"access_token": "tok"}):
+            with patch.object(creator.my_scd_dss_helper, "create_and_submit_operational_intent_reference", new_callable=AsyncMock, return_value=success):
+                result = await creator.submit_flight_declaration_to_dss()
         assert result.status_code == 201
-        mock_state.assert_called_once_with(creator.flight_declaration_id, state=1)
+        mock_fd_repo.update.assert_called_once_with(creator.flight_declaration_id, state=1)
 
     @pytest.mark.asyncio
     async def test_dss_400_error_sets_rejected_state(self):
-        creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.uuid4())
+        mock_fd_repo = AsyncMock()
         fd = _fake_flight_declaration()
-        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.get_by_id", new_callable=AsyncMock, return_value=fd):
-            with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"access_token": "tok"}):
-                with patch.object(
-                    creator.my_scd_dss_helper,
-                    "create_and_submit_operational_intent_reference",
-                    new_callable=AsyncMock,
-                    return_value=_submission_dss_error(400),
-                ):
-                    with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.update", new_callable=AsyncMock) as mock_state:
-                        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.add_state_history_entry", new_callable=AsyncMock):
-                            await creator.submit_flight_declaration_to_dss()
-        mock_state.assert_called_once_with(creator.flight_declaration_id, state=8)
+        mock_fd_repo.get_by_id = AsyncMock(return_value=fd)
+        mock_fd_repo.update = AsyncMock()
+        mock_fd_repo.add_state_history_entry = AsyncMock()
+        creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.uuid4(),
+            fd_repo=mock_fd_repo,
+        )
+        with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"access_token": "tok"}):
+            with patch.object(
+                creator.my_scd_dss_helper,
+                "create_and_submit_operational_intent_reference",
+                new_callable=AsyncMock,
+                return_value=_submission_dss_error(400),
+            ):
+                await creator.submit_flight_declaration_to_dss()
+        mock_fd_repo.update.assert_called_once_with(creator.flight_declaration_id, state=8)
 
     @pytest.mark.asyncio
     async def test_dss_409_error_sets_rejected_state(self):
-        creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.uuid4())
+        mock_fd_repo = AsyncMock()
         fd = _fake_flight_declaration()
-        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.get_by_id", new_callable=AsyncMock, return_value=fd):
-            with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"access_token": "tok"}):
-                with patch.object(
-                    creator.my_scd_dss_helper,
-                    "create_and_submit_operational_intent_reference",
-                    new_callable=AsyncMock,
-                    return_value=_submission_dss_error(409),
-                ):
-                    with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.update", new_callable=AsyncMock) as mock_state:
-                        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.add_state_history_entry", new_callable=AsyncMock):
-                            await creator.submit_flight_declaration_to_dss()
-        mock_state.assert_called_once_with(creator.flight_declaration_id, state=8)
+        mock_fd_repo.get_by_id = AsyncMock(return_value=fd)
+        mock_fd_repo.update = AsyncMock()
+        mock_fd_repo.add_state_history_entry = AsyncMock()
+        creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.uuid4(),
+            fd_repo=mock_fd_repo,
+        )
+        with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"access_token": "tok"}):
+            with patch.object(
+                creator.my_scd_dss_helper,
+                "create_and_submit_operational_intent_reference",
+                new_callable=AsyncMock,
+                return_value=_submission_dss_error(409),
+            ):
+                await creator.submit_flight_declaration_to_dss()
+        mock_fd_repo.update.assert_called_once_with(creator.flight_declaration_id, state=8)
 
     @pytest.mark.asyncio
     async def test_conflict_with_flight_sets_rejected_state(self):
-        creator = DSSOperationalIntentsCreator(flight_declaration_id=uuid.uuid4())
+        mock_fd_repo = AsyncMock()
         fd = _fake_flight_declaration()
-        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.get_by_id", new_callable=AsyncMock, return_value=fd):
-            with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"access_token": "tok"}):
-                with patch.object(
-                    creator.my_scd_dss_helper,
-                    "create_and_submit_operational_intent_reference",
-                    new_callable=AsyncMock,
-                    return_value=_submission_conflict(),
-                ):
-                    with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.update", new_callable=AsyncMock) as mock_state:
-                        with patch("flight_blender.clients.dss_scd_client.SQLAlchemyFlightDeclarationRepository.add_state_history_entry", new_callable=AsyncMock):
-                            await creator.submit_flight_declaration_to_dss()
-        mock_state.assert_called_once_with(creator.flight_declaration_id, state=8)
+        mock_fd_repo.get_by_id = AsyncMock(return_value=fd)
+        mock_fd_repo.update = AsyncMock()
+        mock_fd_repo.add_state_history_entry = AsyncMock()
+        creator = DSSOperationalIntentsCreator(
+            flight_declaration_id=uuid.uuid4(),
+            fd_repo=mock_fd_repo,
+        )
+        with patch.object(creator.my_scd_dss_helper, "get_auth_token", return_value={"access_token": "tok"}):
+            with patch.object(
+                creator.my_scd_dss_helper,
+                "create_and_submit_operational_intent_reference",
+                new_callable=AsyncMock,
+                return_value=_submission_conflict(),
+            ):
+                await creator.submit_flight_declaration_to_dss()
+        mock_fd_repo.update.assert_called_once_with(creator.flight_declaration_id, state=8)

--- a/tests/test_surveillance_tasks.py
+++ b/tests/test_surveillance_tasks.py
@@ -261,49 +261,49 @@ def _mock_sa_repo():
     return repo
 
 
-def _sa_repo_patch(mock_repo):
-    """Patch the async surveillance repository as looked up in the task module."""
-    return patch("flight_blender.tasks.surveillance_task.SQLAlchemySurveillanceRepository", return_value=mock_repo)
+def _svc_patches(mock_repo):
+    """Patch the surveillance service functions."""
+    return [
+        patch("flight_blender.services.surveillance_svc.record_surveillance_heartbeat_event", new_callable=AsyncMock),
+        patch("flight_blender.services.surveillance_svc.record_surveillance_track_event", new_callable=AsyncMock),
+        patch("flight_blender.services.surveillance_svc.get_surveillance_sensor_health", new_callable=AsyncMock, return_value=(100, 5)),
+        patch("flight_blender.services.surveillance_svc.cleanup_old_surveillance_events", new_callable=AsyncMock, return_value=(0, 0)),
+    ]
 
 
 class TestSendHeartbeatToConsumer:
     def test_heartbeat_sent_successfully(self):
         """send_heartbeat_to_consumer should record event when Redis publish succeeds."""
-        mock_repo = _mock_sa_repo()
-        sensor_mock = MagicMock()
-        sensor_mock.expected_latency_ms = 100
-        sensor_mock.horizontal_accuracy_m = 5
-        mock_repo.get_active_surveillance_sensors.return_value = [sensor_mock]
         session_id = str(uuid.uuid4())
         with patch("flight_blender.tasks.surveillance_task.redis.from_url") as mock_from_url:
             mock_from_url.return_value.publish.return_value = 1
             with patch.object(send_heartbeat_to_consumer, "apply_async") as mock_apply_async:
-                with _sa_repo_patch(mock_repo):
-                    send_heartbeat_to_consumer(session_id=session_id)
-        mock_repo.record_heartbeat_event.assert_awaited_once()
+                with patch("flight_blender.tasks.surveillance_task.get_surveillance_sensor_health", new_callable=AsyncMock, return_value=(100, 5)) as mock_health:
+                    with patch("flight_blender.tasks.surveillance_task.record_surveillance_heartbeat_event", new_callable=AsyncMock) as mock_record:
+                        send_heartbeat_to_consumer(session_id=session_id)
+        mock_record.assert_awaited_once()
         mock_from_url.return_value.publish.assert_called_once()
         mock_apply_async.assert_called_once()
 
     def test_heartbeat_channel_error_still_records(self):
         """send_heartbeat_to_consumer records the event even when Redis publish fails."""
-        mock_repo = _mock_sa_repo()
         session_id = str(uuid.uuid4())
         with patch("flight_blender.tasks.surveillance_task.redis.from_url") as mock_from_url:
             mock_from_url.return_value.publish.side_effect = Exception("redis unavailable")
             with patch.object(send_heartbeat_to_consumer, "apply_async") as mock_apply_async:
-                with _sa_repo_patch(mock_repo):
-                    send_heartbeat_to_consumer(session_id=session_id)
+                with patch("flight_blender.tasks.surveillance_task.get_surveillance_sensor_health", new_callable=AsyncMock, return_value=(100, 5)):
+                    with patch("flight_blender.tasks.surveillance_task.record_surveillance_heartbeat_event", new_callable=AsyncMock) as mock_record:
+                        send_heartbeat_to_consumer(session_id=session_id)
         # Even on error, we record the heartbeat
-        mock_repo.record_heartbeat_event.assert_awaited_once()
+        mock_record.assert_awaited_once()
         mock_apply_async.assert_called_once()
-        kwargs = mock_repo.record_heartbeat_event.call_args.kwargs
+        kwargs = mock_record.call_args.kwargs
         assert kwargs.get("delivered_on_time") is False
 
 
 class TestSendAndGenerateTrackToConsumer:
     def test_track_consumer_runs(self):
         """send_and_generate_track_to_consumer calls record_track_event."""
-        mock_repo = _mock_sa_repo()
         session_id = str(uuid.uuid4())
         with patch("flight_blender.tasks.surveillance_task.redis.from_url") as mock_from_url:
             mock_from_url.return_value.publish.return_value = 1
@@ -314,9 +314,9 @@ class TestSendAndGenerateTrackToConsumer:
                         mock_fuser.return_value.generate_track_messages.return_value = []
                         mock_load.return_value = mock_fuser
                         with patch.object(send_and_generate_track_to_consumer, "apply_async") as mock_apply_async:
-                            with _sa_repo_patch(mock_repo):
+                            with patch("flight_blender.tasks.surveillance_task.record_surveillance_track_event", new_callable=AsyncMock) as mock_record:
                                 send_and_generate_track_to_consumer(session_id=session_id)
-        mock_repo.record_track_event.assert_awaited_once()
+        mock_record.assert_awaited_once()
         mock_from_url.return_value.publish.assert_called_once()
         mock_apply_async.assert_called_once()
 
@@ -324,16 +324,13 @@ class TestSendAndGenerateTrackToConsumer:
 class TestCleanupOldHeartbeatEvents:
     def test_cleanup_deletes_old_records(self):
         """cleanup_old_heartbeat_events deletes records older than retention period."""
-        mock_repo = _mock_sa_repo()
-        mock_repo.cleanup_old_events.return_value = (5, 3)
-        with _sa_repo_patch(mock_repo):
+        with patch("flight_blender.tasks.surveillance_task.cleanup_old_surveillance_events", new_callable=AsyncMock, return_value=(5, 3)) as mock_cleanup:
             cleanup_old_heartbeat_events()
-        mock_repo.cleanup_old_events.assert_called_once()
+        mock_cleanup.assert_called_once()
 
     def test_cleanup_with_custom_retention(self, monkeypatch):
         """cleanup_old_heartbeat_events respects HEARTBEAT_RETENTION_DAYS env var."""
         monkeypatch.setattr(settings, "HEARTBEAT_RETENTION_DAYS", 7)
-        mock_repo = _mock_sa_repo()
-        with _sa_repo_patch(mock_repo):
+        with patch("flight_blender.tasks.surveillance_task.cleanup_old_surveillance_events", new_callable=AsyncMock, return_value=(5, 3)) as mock_cleanup:
             cleanup_old_heartbeat_events()
-        mock_repo.cleanup_old_events.assert_called_once()
+        mock_cleanup.assert_called_once()


### PR DESCRIPTION
## Summary

Remove forbidden repository and model imports from task modules by creating service functions that wrap repository operations.

## Changes

### New service functions added:
- `surveillance_svc.py`: record_surveillance_track_event, get_surveillance_sensor_health, record_surveillance_heartbeat_event, cleanup_old_surveillance_events
- `flight_feed_svc.py`: bulk_write_flight_observations, write_flight_observation, get_latest_flight_observation_by_declaration_id
- `geo_fence_svc.py`: save_geofence_feature
- `rid_svc.py`: create_rid_notification, create_rid_subscription, create_or_update_rid_flight_detail, update_telemetry_timestamp, get_rid_subscription, create_rid_observations
- `flight_declarations_svc.py`: submit_flight_declaration_to_dss, get_flight_declaration, get_opint_reference, verify_and_update_declaration_state

### Task files updated:
- `geo_fence_task.py`: Removed GeoFenceORM import, uses save_geofence_feature
- `surveillance_task.py`: Removed SQLAlchemySurveillanceRepository import, uses service functions
- `flight_feed_task.py`: Removed SQLAlchemyFlightFeedRepository import, uses service functions
- `conformance_task.py`: Removed SQLAlchemyFlightFeedRepository import, uses service function
- `flight_declarations_task.py`: Removed SQLAlchemyFlightDeclarationRepository import, uses service functions
- `rid_task.py`: Removed direct repository imports where possible, uses service functions

### Circular import fixes:
- `flight_declarations_svc.py`: Moved CelerySCDNotifier import to TYPE_CHECKING
- `flight_feed_svc.py`: Moved CeleryFlightFeedTaskDispatcher import to TYPE_CHECKING

### Tests updated:
- `test_surveillance_tasks.py`: Updated to patch service functions
- `test_conformance_operations.py`: Updated to patch service functions

## Verification
- All 535 tests pass
- No inline imports in tasks/ (`ruff check --select PLC0415` passes)
- Services imports from tasks are allowed per import hierarchy