### PR TITLE
test(conformance): add integration tests for StatusCode methods

### DIFF
--- a/tests/test_conformance_operations.py
+++ b/tests/test_conformance_operations.py
@@ -318,3 +318,81 @@ class TestOperationConformanceNotification:
                 notif = OperationConformanceNotification(flight_declaration_id="fd-amqp", notifier=notifier)
                 notif.send_conformance_status_notification(message="Some message", level="info")
                 mock_delay.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Conformance service additional coverage
+# ---------------------------------------------------------------------------
+
+
+class TestConformanceServiceCoverage:
+    """Additional tests for conformance_svc."""
+
+    def test_status_code_list(self):
+        """Test StatusCode.list method."""
+        from flight_blender.services.conformance_svc import ConformanceChecksList
+
+        result = ConformanceChecksList.list()
+
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_status_code_text(self):
+        """Test StatusCode.text method."""
+        from flight_blender.services.conformance_svc import ConformanceChecksList
+
+        result = ConformanceChecksList.text(ConformanceChecksList.C2)
+
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_status_code_items(self):
+        """Test StatusCode.items method."""
+        from flight_blender.services.conformance_svc import ConformanceChecksList
+
+        result = ConformanceChecksList.items()
+
+        assert len(list(result)) > 0
+
+    def test_status_code_keys(self):
+        """Test StatusCode.keys method."""
+        from flight_blender.services.conformance_svc import ConformanceChecksList
+
+        result = ConformanceChecksList.keys()
+
+        assert len(list(result)) > 0
+
+    def test_status_code_labels(self):
+        """Test StatusCode.labels method."""
+        from flight_blender.services.conformance_svc import ConformanceChecksList
+
+        result = ConformanceChecksList.labels()
+
+        assert len(list(result)) > 0
+
+    def test_status_code_names(self):
+        """Test StatusCode.names method."""
+        from flight_blender.services.conformance_svc import ConformanceChecksList
+
+        result = ConformanceChecksList.names()
+
+        assert isinstance(result, dict)
+        assert len(result) > 0
+
+    def test_status_code_dict(self):
+        """Test StatusCode.dict method."""
+        from flight_blender.services.conformance_svc import ConformanceChecksList
+
+        result = ConformanceChecksList.dict()
+
+        assert isinstance(result, dict)
+        assert len(result) > 0
+
+    def test_status_code_label(self):
+        """Test StatusCode.label method."""
+        from flight_blender.services.conformance_svc import ConformanceChecksList
+
+        result = ConformanceChecksList.label(ConformanceChecksList.C2)
+
+        assert result is not None
+        assert isinstance(result, str)


### PR DESCRIPTION
## Summary

Add integration tests for the StatusCode methods to improve coverage of the conformance service.

## Changes

### New tests added:
- `test_status_code_list`: Tests StatusCode.list method
- `test_status_code_text`: Tests StatusCode.text method
- `test_status_code_items`: Tests StatusCode.items method
- `test_status_code_keys`: Tests StatusCode.keys method
- `test_status_code_labels`: Tests StatusCode.labels method
- `test_status_code_names`: Tests StatusCode.names method
- `test_status_code_dict`: Tests StatusCode.dict method
- `test_status_code_label`: Tests StatusCode.label method

## Coverage improvement

- conformance_svc.py: Additional coverage for StatusCode methods

## Verification
- All 543 tests pass
- No regressions