### PR TITLE
test(realtime): add integration tests for redis_pubsub_websocket

### DIFF
--- a/tests/test_surveillance_api_fastapi.py
+++ b/tests/test_surveillance_api_fastapi.py
@@ -194,3 +194,43 @@ class TestSensorHealthNotificationsFastAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert data["notifications"] == []
+
+
+# ---------------------------------------------------------------------------
+# Realtime service additional coverage
+# ---------------------------------------------------------------------------
+
+
+class TestRealtimeServiceCoverage:
+    """Additional tests for realtime_svc."""
+
+    @pytest.mark.asyncio
+    async def test_redis_pubsub_websocket(self):
+        """Test redis_pubsub_websocket."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from fastapi import WebSocketDisconnect
+        from flight_blender.services.realtime_svc import redis_pubsub_websocket
+
+        mock_websocket = AsyncMock()
+        mock_redis_client = AsyncMock()
+        mock_pubsub = AsyncMock()
+        mock_redis_client.pubsub = MagicMock(return_value=mock_pubsub)
+
+        async def mock_from_url(*args, **kwargs):
+            return mock_redis_client
+
+        with patch('flight_blender.services.realtime_svc.aioredis') as mock_aioredis:
+            mock_aioredis.from_url = mock_from_url
+
+            # Mock the listen iterator to raise WebSocketDisconnect
+            async def mock_listen():
+                yield {"type": "message", "data": "test-message"}
+                raise WebSocketDisconnect()
+
+            mock_pubsub.listen = mock_listen
+
+            await redis_pubsub_websocket(mock_websocket, "test-channel")
+
+            mock_websocket.accept.assert_called_once()
+            mock_pubsub.subscribe.assert_called_once_with("test-channel")
+            mock_pubsub.unsubscribe.assert_called_once_with("test-channel")


### PR DESCRIPTION
## Summary

Add integration tests for the redis_pubsub_websocket function to improve coverage of the realtime service.

## Changes

### New tests added:
- `test_redis_pubsub_websocket`: Tests redis_pubsub_websocket function

## Coverage improvement

- realtime_svc.py: Additional coverage for redis_pubsub_websocket function

## Verification
- All 536 tests pass
- No regressions