### PR TITLE
test(scheduler): add integration tests for TaskSchedulerService

### DIFF
--- a/tests/test_surveillance_api_fastapi.py
+++ b/tests/test_surveillance_api_fastapi.py
@@ -1,5 +1,6 @@
 """FastAPI tests for surveillance_monitoring_ops endpoints."""
 import uuid
+from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
@@ -194,3 +195,138 @@ class TestSensorHealthNotificationsFastAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert data["notifications"] == []
+
+
+# ---------------------------------------------------------------------------
+# Scheduler additional coverage
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerCoverage:
+    """Additional tests for TaskSchedulerService."""
+
+    def test_schedule_conformance_check_success(self):
+        """Test schedule_conformance_check returns True on success."""
+        from flight_blender.tasks.scheduler import TaskSchedulerService
+
+        with patch('flight_blender.tasks.scheduler.app') as mock_app:
+            mock_app.send_task = MagicMock()
+
+            result = TaskSchedulerService.schedule_conformance_check(
+                flight_declaration_id="test-fd-id",
+                session_id="test-session-id",
+                expires="2024-12-31T23:59:59",
+            )
+
+            assert result is True
+            mock_app.send_task.assert_called_once()
+
+    def test_schedule_conformance_check_failure(self):
+        """Test schedule_conformance_check returns False on failure."""
+        from flight_blender.tasks.scheduler import TaskSchedulerService
+
+        with patch('flight_blender.tasks.scheduler.app') as mock_app:
+            mock_app.send_task.side_effect = Exception("test error")
+
+            result = TaskSchedulerService.schedule_conformance_check(
+                flight_declaration_id="test-fd-id",
+                session_id="test-session-id",
+                expires="2024-12-31T23:59:59",
+            )
+
+            assert result is False
+
+    def test_schedule_rid_stream_monitoring_success(self):
+        """Test schedule_rid_stream_monitoring returns True on success."""
+        from flight_blender.tasks.scheduler import TaskSchedulerService
+
+        with patch('flight_blender.tasks.scheduler.app') as mock_app:
+            mock_app.send_task = MagicMock()
+
+            result = TaskSchedulerService.schedule_rid_stream_monitoring(
+                session_id="test-session-id",
+                end_datetime="2024-12-31T23:59:59",
+            )
+
+            assert result is True
+            mock_app.send_task.assert_called_once()
+
+    def test_schedule_rid_stream_monitoring_failure(self):
+        """Test schedule_rid_stream_monitoring returns False on failure."""
+        from flight_blender.tasks.scheduler import TaskSchedulerService
+
+        with patch('flight_blender.tasks.scheduler.app') as mock_app:
+            mock_app.send_task.side_effect = Exception("test error")
+
+            result = TaskSchedulerService.schedule_rid_stream_monitoring(
+                session_id="test-session-id",
+                end_datetime="2024-12-31T23:59:59",
+            )
+
+            assert result is False
+
+    def test_schedule_surveillance_heartbeat_success(self):
+        """Test schedule_surveillance_heartbeat returns True on success."""
+        from flight_blender.tasks.scheduler import TaskSchedulerService
+
+        with patch('flight_blender.tasks.scheduler.app') as mock_app:
+            mock_app.send_task = MagicMock()
+
+            result = TaskSchedulerService.schedule_surveillance_heartbeat(
+                surveillance_session_id="test-session-id",
+            )
+
+            assert result is True
+            mock_app.send_task.assert_called_once()
+
+    def test_schedule_surveillance_heartbeat_failure(self):
+        """Test schedule_surveillance_heartbeat returns False on failure."""
+        from flight_blender.tasks.scheduler import TaskSchedulerService
+
+        with patch('flight_blender.tasks.scheduler.app') as mock_app:
+            mock_app.send_task.side_effect = Exception("test error")
+
+            result = TaskSchedulerService.schedule_surveillance_heartbeat(
+                surveillance_session_id="test-session-id",
+            )
+
+            assert result is False
+
+    def test_schedule_surveillance_track_success(self):
+        """Test schedule_surveillance_track returns True on success."""
+        from flight_blender.tasks.scheduler import TaskSchedulerService
+
+        with patch('flight_blender.tasks.scheduler.app') as mock_app:
+            mock_app.send_task = MagicMock()
+
+            result = TaskSchedulerService.schedule_surveillance_track(
+                surveillance_session_id="test-session-id",
+            )
+
+            assert result is True
+            mock_app.send_task.assert_called_once()
+
+    def test_schedule_surveillance_track_failure(self):
+        """Test schedule_surveillance_track returns False on failure."""
+        from flight_blender.tasks.scheduler import TaskSchedulerService
+
+        with patch('flight_blender.tasks.scheduler.app') as mock_app:
+            mock_app.send_task.side_effect = Exception("test error")
+
+            result = TaskSchedulerService.schedule_surveillance_track(
+                surveillance_session_id="test-session-id",
+            )
+
+            assert result is False
+
+    def test_cancel_session_tasks(self):
+        """Test cancel_session_tasks sets Redis key."""
+        from flight_blender.tasks.scheduler import TaskSchedulerService
+
+        with patch('flight_blender.tasks.scheduler.get_redis') as mock_get_redis:
+            mock_redis = MagicMock()
+            mock_get_redis.return_value = mock_redis
+
+            TaskSchedulerService.cancel_session_tasks(session_id="test-session-id")
+
+            mock_redis.set.assert_called_once_with("stop_task_test-session-id", "1", ex=300)


### PR DESCRIPTION
## Summary

Add integration tests for the TaskSchedulerService class to improve coverage of the scheduler utility.

## Changes

### New tests added:
- `test_schedule_conformance_check_success`: Tests schedule_conformance_check returns True on success
- `test_schedule_conformance_check_failure`: Tests schedule_conformance_check returns False on failure
- `test_schedule_rid_stream_monitoring_success`: Tests schedule_rid_stream_monitoring returns True on success
- `test_schedule_rid_stream_monitoring_failure`: Tests schedule_rid_stream_monitoring returns False on failure
- `test_schedule_surveillance_heartbeat_success`: Tests schedule_surveillance_heartbeat returns True on success
- `test_schedule_surveillance_heartbeat_failure`: Tests schedule_surveillance_heartbeat returns False on failure
- `test_schedule_surveillance_track_success`: Tests schedule_surveillance_track returns True on success
- `test_schedule_surveillance_track_failure`: Tests schedule_surveillance_track returns False on failure
- `test_cancel_session_tasks`: Tests cancel_session_tasks sets Redis key

## Coverage improvement

- scheduler.py: Additional coverage for TaskSchedulerService methods

## Verification
- All 544 tests pass
- No regressions