### PR TITLE
Allow activated updates with preexisting conflicts

### DIFF
--- a/src/flight_blender/clients/dss_scd_client.py
+++ b/src/flight_blender/clients/dss_scd_client.py
@@ -977,6 +977,7 @@ class SCDOperations:
         new_state: str,
         extents_conflict_with_dss_volumes: bool,
         priority: int,
+        preexisting_conflict: bool = False,
     ) -> ShouldSendtoDSSProcessingResponse:
         should_opint_be_sent_to_dss = ShouldSendtoDSSProcessingResponse(
             should_submit_update_payload_to_dss=0,
@@ -987,7 +988,9 @@ class SCDOperations:
         activated = OperationalIntentState.Activated.value
         off_nominal_states = (OperationalIntentState.Nonconforming.value, OperationalIntentState.Contingent.value)
 
-        if current_state == activated and new_state == activated and extents_conflict_with_dss_volumes:
+        # An already-activated intent may be updated while its conflict persists.
+        # Only reject an update that newly introduces a conflict.
+        if current_state == activated and new_state == activated and extents_conflict_with_dss_volumes and not preexisting_conflict:
             logger.debug("Case B")
             should_opint_be_sent_to_dss.should_submit_update_payload_to_dss = 0
             should_opint_be_sent_to_dss.check_id = OpIntUpdateCheckResultCodes.B
@@ -1026,6 +1029,7 @@ class SCDOperations:
         ovn: str,
         deconfliction_check=False,
         priority: int = 0,
+        previous_extents: list[Volume4D] | None = None,
     ) -> OperationalIntentUpdateResponse:
         """
         Update a specified operational intent reference in the DSS.
@@ -1097,14 +1101,20 @@ class SCDOperations:
                 all_existing_operational_intent_details=all_existing_operational_intent_details,
                 extents=extents,
             )
+            preexisting_conflict = bool(previous_extents) and self.check_extents_conflict_with_latest_volumes(
+                all_existing_operational_intent_details=all_existing_operational_intent_details,
+                extents=previous_extents,
+            )
         else:
             extents_conflict_with_dss_volumes = False
+            preexisting_conflict = False
 
         pre_submission_checks = self.check_if_update_payload_should_be_submitted_to_dss(
             current_state=current_state,
             new_state=new_state,
             extents_conflict_with_dss_volumes=extents_conflict_with_dss_volumes,
             priority=priority,
+            preexisting_conflict=preexisting_conflict,
         )
 
         if not pre_submission_checks.should_submit_update_payload_to_dss:

--- a/src/flight_blender/services/scd_svc.py
+++ b/src/flight_blender/services/scd_svc.py
@@ -604,6 +604,7 @@ class SCDService:
             deconfliction_check=self._should_deconflict(current_state_str, ctx.generated_state),
             priority=ctx.request.intended_flight.astm_f3548_21.priority,
             ovn=stored_details.reference.ovn,
+            previous_extents=existing_op_int_details.operational_intent_details.volumes if existing_op_int_details else None,
         )
         if update_job.status == 200:
             return await self._handle_successful_update(ctx, update_job, stored_details, existing_op_int_details)

--- a/tests/test_scd_dss_helper.py
+++ b/tests/test_scd_dss_helper.py
@@ -531,6 +531,20 @@ class TestOperationalIntentUpdatePreSubmissionChecks:
         assert response.check_id == OpIntUpdateCheckResultCodes.B
         assert response.tentative_flight_plan_processing_response == FlightPlanCurrentStatus.OkToFly
 
+    def test_activated_update_with_preexisting_conflict_is_submitted(self):
+        ops = dss_helper.SCDOperations()
+
+        response = ops.check_if_update_payload_should_be_submitted_to_dss(
+            current_state=OperationalIntentState.Activated.value,
+            new_state=OperationalIntentState.Activated.value,
+            extents_conflict_with_dss_volumes=True,
+            priority=0,
+            preexisting_conflict=True,
+        )
+
+        assert response.should_submit_update_payload_to_dss == 1
+        assert response.check_id == OpIntUpdateCheckResultCodes.A
+
 
 class TestPeerUSSNotification:
     async def test_notify_auth_failure_raises_http_exception(self, monkeypatch):


### PR DESCRIPTION
## Summary

- Allow updates to activated flight plans when their conflict already existed before the update.
- Keep rejecting activated-flight updates that introduce a new conflict.
- Add a regression test for the pre-existing-conflict decision.

## Root cause

The SCD update pre-submission check only examined the requested extents. It therefore rejected a valid modification of an activated flight plan whenever the requested extents still overlapped an existing conflict, producing the InterUSS SCD0030 warning.

## Validation

- `uv run pytest tests/test_scd_dss_helper.py tests/test_scd_operations.py -q`
- `uv run ruff check src/flight_blender/clients/dss_scd_client.py src/flight_blender/services/scd_svc.py tests/test_scd_dss_helper.py`
